### PR TITLE
feat(cli): add modern Rust-based CLI tools for all platforms

### DIFF
--- a/dot_zshrc
+++ b/dot_zshrc
@@ -51,6 +51,11 @@ if command -v fnm >/dev/null 2>&1; then
   eval "$(fnm env --use-on-cd)"
 fi
 
+# Smart directory jumping with zoxide
+if command -v zoxide >/dev/null 2>&1; then
+  eval "$(zoxide init zsh)"
+fi
+
 # Create missing completion directories to prevent errors (all platforms)
 mkdir -p ~/.antigen/bundles/robbyrussell/oh-my-zsh/cache/completions 2>/dev/null
 
@@ -119,8 +124,21 @@ alias h="history"
 if command -v btop >/dev/null 2>&1; then
   alias top="btop"
 fi
+
+# Disk usage tools
 if command -v ncdu >/dev/null 2>&1; then
   alias du="ncdu"
+fi
+if command -v duf >/dev/null 2>&1; then
+  alias df="duf"
+fi
+if command -v dust >/dev/null 2>&1; then
+  alias dust-tree="dust"  # Keep 'dust' command, add tree variant
+fi
+
+# Process viewer
+if command -v procs >/dev/null 2>&1; then
+  alias ps="procs"
 fi
 
 # Enable better completion handling - ENHANCED VERSION

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -23,12 +23,17 @@
 
 {{ $modernCli := list
      "bat"
-     "eza" 
+     "eza"
      "fd"
      "git-delta"
      "ncdu"
      "httpie"
-     "tmux" -}}
+     "tmux"
+     "zoxide"
+     "duf"
+     "hyperfine"
+     "procs"
+     "dust" -}}
 
 {{ $macosSpecific := list 
      "python" 
@@ -173,8 +178,9 @@ echo '   Or: eval "$(~/.linuxbrew/bin/brew shellenv)"'
 brew install {{ $allBrewPackages | join " " }}
 {{ else -}}
 # Install modern CLI tools via apt for non-amd64 architectures
-{{ $sudo }}apt-get install -y bat fd-find ncdu tmux
-# Note: eza, delta, httpie may need alternative installation methods on ARM
+{{ $sudo }}apt-get install -y bat fd-find ncdu tmux duf hyperfine
+# Note: eza, delta, httpie, procs, dust may need alternative installation methods on ARM
+# Some of these may not be available on older Ubuntu/Debian versions
 {{ end -}}
 
 # Set up fnm and install Node.js (after Homebrew packages are installed)


### PR DESCRIPTION
Add new Rust-based CLI tools from It's FOSS recommendations:
- zoxide: smart directory jumping (replaces cd)
- duf: beautiful disk usage display (replaces df)
- hyperfine: command benchmarking tool (replaces time)
- procs: modern process viewer (replaces ps)
- dust: visual disk usage analyzer (alternative to du/ncdu)

Changes:
- Updated $modernCli list to include new tools
- Added apt fallback for ARM/non-amd64 architectures
- Configured zoxide initialization in .zshrc
- Added aliases: df->duf, ps->procs
- Maintained backward compatibility with all platforms

These tools complement existing setup (bat, eza, fd, ripgrep, btop, ncdu) and work across macOS, Linux, and WSL installations.