### PR TITLE
feat: add dotfiles agent and human-readable documentation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,39 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(chezmoi status:*)",
+      "Bash(chezmoi diff:*)",
+      "Bash(chezmoi doctor:*)",
+      "Bash(chezmoi managed:*)",
+      "Bash(chezmoi data:*)",
+      "Bash(chezmoi execute-template:*)",
+      "Bash(chezmoi apply --dry-run:*)",
+      "Bash(chezmoi cat-config:*)",
+      "Bash(sysup doctor:*)",
+      "Bash(sysup status:*)",
+      "Bash(brew list:*)",
+      "Bash(brew info:*)",
+      "Bash(apt list:*)",
+      "Bash(command -v:*)",
+      "Bash(which:*)",
+      "Bash(uname:*)",
+      "Bash(git status:*)",
+      "Bash(git log:*)",
+      "Bash(git diff:*)",
+      "Bash(ls:*)",
+      "Bash(find:*)",
+      "Bash(cat:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)",
+      "Bash(rg:*)",
+      "Bash(grep:*)",
+      "Bash(fd:*)",
+      "Bash(tree:*)",
+      "Bash(bat:*)",
+      "Bash(eza:*)",
+      "Read(*)",
+      "Glob(*)",
+      "Grep(*)"
+    ]
+  }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,18 +117,12 @@ On new interactive shells (local terminals, SSH logins), a welcome message shows
 ### Multi-Service Orchestration
 For complex multi-service setups, copy `~/.local/share/start-service.sh.example` to your project directory and customize it.
 
-## Recent Changes
+## Documentation
 
-1. **Dev session manager**: Replaced tmux-session with `dev` command (fzf picker, project discovery, layouts)
-2. **TPM & session persistence**: Enabled tmux-resurrect and tmux-continuum for automatic session save/restore
-3. **Welcome message**: Replaced SSH-only tmux reminder with general welcome message (hostname, platform, commands, active sessions)
-4. **Service templates**: Example script for managing project services
-5. **PATH syntax error**: Fixed semicolon separator in PATH export
-6. **Antigen cache directory**: Moved creation outside WSL-specific block
-7. **Cross-platform compatibility**: Ensured all platforms can create necessary directories
-8. **VS Code configuration**: Added comprehensive settings, keybindings, and extensions
-9. **TTY warning**: Known issue with antigen during `chezmoi apply` (cosmetic only)
-10. **sysup utility**: Cross-platform system update command (brew, apt, fnm, uv, pipx, tpm, vscode, chezmoi)
+Detailed usage guides are in `docs/`:
+- [`docs/dev.md`](docs/dev.md) — Dev session manager reference
+- [`docs/sysup.md`](docs/sysup.md) — System update utility reference
+- [`docs/dotfiles-agent.md`](docs/dotfiles-agent.md) — Dotfiles agent setup and usage
 
 ## When Making Changes
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,10 @@ Per-project layouts are configured in `~/.config/dev/config`:
 default_layout=default
 atomicguard=claude
 manta-deploy=claude
+dotfiles=claude:~/.local/share/chezmoi
 ```
+
+Format: `project=layout[:path][@host]` — `:path` for custom directories, `@host` for remote SSH.
 
 ### Layouts
 - **default**: Single shell pane in the project directory
@@ -141,3 +144,47 @@ For complex multi-service setups, copy `~/.local/share/start-service.sh.example`
 - Check template syntax with `chezmoi execute-template`
 - Verify file permissions and PATH configuration
 - Ensure platform-specific code is properly guarded
+
+## Package Management Workflow
+
+When adding a new package or CLI tool to the dotfiles, follow these steps:
+
+### 1. Install Script (`run_once_install-packages.sh.tmpl`)
+
+Add the package to the appropriate list:
+- `$commonPackages` — core utilities available everywhere (curl, jq, ripgrep, etc.)
+- `$brewPackages` — Homebrew-only tools (fnm, btop, gh, etc.)
+- `$modernCli` — modern replacements for standard commands (bat, eza, fd, etc.)
+- `$macosSpecific` — macOS-only packages (docker, awscli, etc.)
+- `$linuxSpecific` / `$linuxWithDocker` — Linux/WSL apt packages
+
+### 2. Doctor Check (`dot_local/bin/executable_sysup`)
+
+Add the tool to the appropriate array in the `doctor` command:
+- `tools_pm` — package managers (brew, apt-get, fnm, uv, etc.)
+- `tools_dev` — development tools (git, tmux, docker, etc.)
+- `tools_cli` — modern CLI replacements (eza, bat, fd, rg, etc.)
+
+If the tool has a non-standard version flag, add a case to `get_version()`.
+
+### 3. Shell Aliases (`dot_zshrc`)
+
+If the new tool replaces a standard command, add a conditional alias:
+```zsh
+if command -v newtool >/dev/null 2>&1; then
+  alias oldcmd="newtool"
+fi
+```
+
+Only add aliases when the tool is a drop-in replacement. Skip this step for tools with their own unique commands.
+
+### 4. Documentation
+
+Update this file (CLAUDE.md) if the package changes any documented behavior.
+
+### 5. Verification Checklist
+
+- [ ] `chezmoi execute-template < run_once_install-packages.sh.tmpl` — template renders
+- [ ] `chezmoi apply --dry-run` — all changes deploy cleanly
+- [ ] `sysup doctor` — new tool appears in the correct section
+- [ ] Aliases work: open a new shell and verify `command -v <tool>`

--- a/README.md
+++ b/README.md
@@ -56,13 +56,24 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
 .
 ├── dot_zshrc                           # Zsh configuration
 ├── dot_p10k.zsh                       # Powerlevel10k theme config
+├── dot_tmux.conf                      # Tmux configuration (TPM, resurrect, continuum)
 ├── dot_claude/                        # Claude Code configuration
 │   └── settings.json
-├── dot_config/Code/User/               # VS Code configuration
-│   ├── settings.json.tmpl             # VS Code settings
-│   ├── keybindings.json               # Custom keybindings
-│   └── extensions.json                # Recommended extensions
+├── dot_config/
+│   ├── Code/User/                     # VS Code configuration
+│   │   ├── settings.json.tmpl         # VS Code settings
+│   │   ├── keybindings.json           # Custom keybindings
+│   │   └── extensions.json            # Recommended extensions
+│   └── dev/config                     # Dev session manager config
+├── dot_local/bin/
+│   ├── executable_dev                 # Dev session manager
+│   └── executable_sysup               # System update utility
+├── docs/                              # Detailed documentation
+│   ├── dev.md                         # Dev session manager reference
+│   ├── sysup.md                       # System update utility reference
+│   └── dotfiles-agent.md             # Dotfiles agent guide
 ├── run_once_install-packages.sh.tmpl  # Package installation script
+├── run_once_after_install-tpm.sh      # TPM auto-installer
 └── run_once_after_chsh.sh.tmpl       # Shell change script
 ```
 
@@ -101,22 +112,35 @@ The zsh configuration includes:
 - Platform-specific configurations
 - Tmux integration with convenient aliases
 
-### Tmux for Remote Development
+### Dev Session Manager
 
-Includes a complete tmux setup optimized for remote development:
-- **Modern keybindings**: Vim-style navigation with `C-a` prefix
-- **Session helpers**: `tmux-session` script for easy session management
-- **Service templates**: Example scripts for running project services
-- **Mouse support**: Toggle-able mouse mode for convenience
-- **Cross-platform**: Works seamlessly on macOS, Linux, and WSL
+The `dev` command provides persistent tmux sessions for multi-device development:
+- **Project discovery**: Auto-discovers projects from `~/Projects/`
+- **Interactive picker**: fzf-powered (with numbered fallback) session/project selector
+- **Layouts**: Single shell or Claude Code + shell split
+- **Remote support**: SSH-transparent session management via `@host` config
+- **Session persistence**: Auto-saved every 15 minutes via tmux-resurrect/continuum
 
 Quick start:
 ```bash
-tms myproject          # Create/attach to session
-./start-service.sh     # Use template in your projects
+dev                    # Interactive picker
+dev myproject          # Create/attach to session
+dev claude myproject   # Force Claude Code + shell layout
 ```
 
-See `~/.local/share/start-service.sh.example` for project integration patterns.
+See [docs/dev.md](docs/dev.md) for the full reference.
+
+### System Updates
+
+The `sysup` command manages all package managers from a single entry point:
+
+```bash
+sysup                  # Check what's outdated
+sysup upgrade          # Update everything
+sysup doctor           # Verify tool installation
+```
+
+See [docs/sysup.md](docs/sysup.md) for the full reference.
 
 ### VS Code Configuration
 
@@ -126,6 +150,14 @@ The VS Code setup includes:
 - **Extensions**: Curated list of recommended extensions for development
 - **Database support**: SQLite viewer and SQLTools integration
 - **Language support**: Python, JavaScript, TypeScript, Rust, Go, and more
+
+## Documentation
+
+Detailed usage guides for the custom tools in this repository:
+
+- [Dev Session Manager](docs/dev.md) -- persistent tmux sessions for multi-device development
+- [System Update Utility](docs/sysup.md) -- cross-platform package manager orchestration
+- [Dotfiles Agent](docs/dotfiles-agent.md) -- Claude Code + shell session for dotfiles maintenance
 
 ## Troubleshooting
 

--- a/docs/dev.md
+++ b/docs/dev.md
@@ -1,0 +1,181 @@
+# Dev Session Manager
+
+`dev` is a persistent tmux session manager for multi-device development. It provides a single entry point for creating, attaching to, and managing tmux sessions with automatic project discovery.
+
+Sessions survive disconnects, reboots (via tmux-resurrect), and can be accessed from any device via SSH.
+
+**Source:** `~/.local/bin/dev` (`dot_local/bin/executable_dev` in chezmoi)
+
+## Synopsis
+
+```bash
+dev                     # Interactive picker (fzf or numbered fallback)
+dev <project>           # Create or attach to session for <project>
+dev claude <project>    # Force claude+shell layout (vertical split)
+dev detach              # Detach from current tmux session
+dev kill <name>         # Kill a session
+dev kill-all            # Kill all sessions (with confirmation)
+dev help                # Show built-in help
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `dev` | Open the interactive picker to select a session or project |
+| `dev <project>` | Create a new session (or attach if it exists) for `<project>` |
+| `dev claude <project>` | Same as above but forces the `claude` layout regardless of config |
+| `dev detach` | Detach from the current tmux session (must be inside tmux) |
+| `dev kill <name>` | Kill the named session |
+| `dev kill-all` | Kill all tmux sessions (prompts for confirmation) |
+| `dev help` | Show the built-in help text |
+
+## Layouts
+
+| Layout | Panes | Description |
+|--------|-------|-------------|
+| `default` | 1 | Single shell pane in the project directory |
+| `claude` | 2 | Vertical split -- Claude Code (left) + shell (right) |
+
+The layout for a project is determined by (in priority order):
+1. The `force_layout` argument (`dev claude <project>`)
+2. The per-project setting in `~/.config/dev/config`
+3. The `default_layout` setting in the config file
+4. Falls back to `default`
+
+## Project Discovery
+
+Projects are auto-discovered from `~/Projects/` by scanning up to 3 levels deep for directories containing a `.git` folder.
+
+If two projects share the same basename (e.g. `work/api` and `personal/api`), `dev` uses the `category/project` form to disambiguate them in the picker and tab completion.
+
+Custom-path projects defined in the config file are appended to the discovery list and also appear in the interactive picker and tab completion.
+
+## Configuration
+
+Per-project settings are stored in `~/.config/dev/config`:
+
+```ini
+# Default layout for all projects (optional, defaults to "default")
+default_layout=default
+
+# Per-project overrides
+atomicguard=claude                           # layout only
+manta-deploy=claude@myserver                 # layout + remote host
+dotfiles=claude:~/.local/share/chezmoi       # layout + custom path
+myproject=default:/opt/myproject@server      # all three
+```
+
+### Format
+
+```
+project=layout[:path][@host]
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `layout` | yes | `default` or `claude` |
+| `:path` | no | Custom directory (expands `~`). Omit for projects under `~/Projects`. |
+| `@host` | no | SSH hostname. If set and local hostname differs, `dev` will SSH to that host. |
+
+When a project has a custom `:path`, the config key (e.g. `dotfiles`) is used as the tmux session name instead of the directory basename.
+
+### Adding a Custom-Path Project
+
+1. Open `~/.config/dev/config` (create it if it doesn't exist)
+2. Add a line: `myproject=claude:/path/to/project`
+3. Run `dev myproject` -- a session will be created in `/path/to/project` with the `claude` layout
+4. Tab completion picks up the new name immediately
+
+## Remote Projects
+
+If a project has `@host` in its config and the local hostname doesn't match, `dev` will SSH to the remote host and run `dev` there transparently. This works for:
+
+- Opening sessions (`dev myproject`)
+- Killing sessions (`dev kill myproject`)
+- The interactive picker (remote-only projects appear in the list)
+
+Projects that only exist on a remote host still appear in the picker with an `@host` annotation.
+
+### How it works
+
+1. `dev` reads the `@host` suffix from the config
+2. Compares it against the local `hostname -s`
+3. If they differ, runs `ssh -t <host> dev <args>` instead of acting locally
+
+## Interactive Picker
+
+Running `dev` with no arguments opens the interactive picker.
+
+### fzf mode (if fzf is installed)
+
+A fuzzy-searchable list with two sections:
+- **[session]** entries for active tmux sessions (with layout type and last-activity time)
+- **[project]** entries for discovered + custom-path projects not yet open
+
+### Fallback mode (no fzf)
+
+A numbered list with a `Select [1-N]:` prompt, grouped into:
+1. **Active Sessions** -- existing tmux sessions
+2. **Available Projects** -- projects without an active session
+
+## Tab Completion
+
+Tab completion is configured in `dot_zshrc`. `dev <TAB>` completes:
+- Subcommands: `claude`, `detach`, `kill`, `kill-all`, `help`
+- Active tmux session names
+- Discovered projects from `~/Projects`
+- Custom-path project names from the config file
+
+## Tmux Keybindings
+
+The tmux prefix is `C-a` (Ctrl+a). Key bindings:
+
+| Binding | Action |
+|---------|--------|
+| `C-a \|` | Split horizontally |
+| `C-a -` | Split vertically |
+| `C-a h/j/k/l` | Navigate panes (vim-style) |
+| `C-a r` | Reload tmux config |
+| `C-a d` | Detach from session |
+
+## Session Persistence
+
+Sessions are automatically saved every 15 minutes via **tmux-continuum** and restored on tmux server start via **tmux-resurrect**.
+
+| Action | Keybinding |
+|--------|------------|
+| Install/update TPM plugins | `prefix + I` |
+| Manual save | `prefix + Ctrl-s` |
+| Manual restore | `prefix + Ctrl-r` |
+
+TPM is auto-installed by `run_once_after_install-tpm.sh` during chezmoi setup.
+
+## Multi-Service Orchestration
+
+For projects that need multiple background services, copy `~/.local/share/start-service.sh.example` to your project directory and customize it. The template provides a pattern for starting, stopping, and monitoring services within tmux panes.
+
+## Examples
+
+```bash
+# Pick a project interactively
+dev
+
+# Open atomicguard with its configured layout
+dev atomicguard
+
+# Open dotfiles in the chezmoi source directory (custom path from config)
+dev dotfiles
+
+# Force claude+shell layout for any project
+dev claude myproject
+
+# Kill a session
+dev kill myproject
+
+# Kill all sessions (will prompt for confirmation)
+dev kill-all
+
+# Detach from current session (inside tmux)
+dev detach
+```

--- a/docs/dotfiles-agent.md
+++ b/docs/dotfiles-agent.md
@@ -1,0 +1,79 @@
+# Dotfiles Agent
+
+The dotfiles agent is a Claude Code + shell tmux session for maintaining this chezmoi repository. It is pre-configured as a custom-path project in the dev session manager.
+
+## Quick Start
+
+```bash
+dev dotfiles
+```
+
+This creates (or reattaches to) a tmux session named `dotfiles` in `~/.local/share/chezmoi` with the `claude` layout: Claude Code on the left pane, a shell on the right.
+
+## What Happens
+
+1. `dev` looks up `dotfiles` in `~/.config/dev/config` and finds `claude:~/.local/share/chezmoi`
+2. Extracts layout `claude` and path `~/.local/share/chezmoi`
+3. Creates tmux session `dotfiles` with a vertical split
+4. Left pane: runs `claude` (Claude Code CLI) in the chezmoi source directory
+5. Right pane: shell in the same directory for manual commands
+
+## Project-Level Permissions
+
+The session uses project-level Claude Code permissions defined in `.claude/settings.json`. Read-only operations are auto-approved:
+
+| Category | Auto-approved commands |
+|----------|----------------------|
+| chezmoi | `status`, `diff`, `doctor`, `managed`, `data`, `execute-template`, `apply --dry-run`, `cat-config` |
+| sysup | `doctor`, `status` |
+| git | `status`, `log`, `diff` |
+| File browsing | `ls`, `find`, `cat`, `head`, `tail`, `rg`, `grep`, `fd`, `tree`, `bat`, `eza` |
+| System info | `command -v`, `which`, `uname`, `brew list`, `brew info`, `apt list` |
+
+**Write operations require approval:** `chezmoi apply`, `git commit`, file edits, package installation, etc.
+
+## Example Tasks
+
+### Check system state (auto-approved, no prompts)
+
+In the Claude Code pane, ask:
+
+```
+"What packages are installed?"          # runs brew list, apt list
+"Run sysup doctor"                      # checks all tool versions
+"What chezmoi changes are pending?"     # runs chezmoi status, chezmoi diff
+"Show the git log"                      # runs git log
+```
+
+### Make changes (will prompt for approval)
+
+```
+"Add ripgrep to the install script"     # edits run_once_install-packages.sh.tmpl
+"Add a new alias for tldr"             # edits dot_zshrc
+"Update the tmux prefix key"           # edits dot_tmux.conf
+"Apply the changes"                     # runs chezmoi apply
+```
+
+## Using the Shell Pane
+
+The right pane is a regular shell in the chezmoi source directory. Use it for:
+
+```bash
+chezmoi apply --dry-run      # Preview what chezmoi would change
+chezmoi diff                 # See pending diffs
+chezmoi status               # List modified files
+git status                   # Check repo state
+git log --oneline -10        # Recent commits
+sysup doctor                 # Verify tool health
+```
+
+## Session Lifecycle
+
+```bash
+dev dotfiles        # Create or reattach
+C-a d               # Detach (session stays alive in background)
+dev dotfiles        # Reattach later, from any terminal or SSH session
+dev kill dotfiles   # Destroy the session when done
+```
+
+Sessions persist across disconnects and are auto-saved by tmux-resurrect every 15 minutes.

--- a/docs/sysup.md
+++ b/docs/sysup.md
@@ -1,0 +1,92 @@
+# System Update Utility (sysup)
+
+`sysup` is a cross-platform system update utility that manages all package managers and tools from a single entry point. It works on macOS, Linux, and WSL.
+
+**Source:** `~/.local/bin/sysup` (`dot_local/bin/executable_sysup` in chezmoi)
+
+## Synopsis
+
+```bash
+sysup                   # Show what's outdated (same as sysup status)
+sysup status            # Read-only: check each package manager for updates
+sysup upgrade           # Apply all updates
+sysup doctor            # Check which tools are installed + versions
+sysup version           # Show sysup version
+sysup help              # Show built-in help
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `sysup` / `sysup status` | Check each package manager for available updates (read-only) |
+| `sysup upgrade` | Apply all updates across every installed package manager |
+| `sysup doctor` | Report installed tools, versions, and key filesystem paths |
+| `sysup version` | Print the sysup version |
+| `sysup help` | Show the built-in help text |
+
+## Modules
+
+Modules are checked in the order listed below. Each module is **skipped** if its tool isn't installed.
+
+| Module | What it does | Platform |
+|--------|-------------|----------|
+| `brew` | Updates Homebrew formulae. On macOS, also upgrades casks. Runs `brew cleanup --prune=30` after upgrading. | All |
+| `apt` | Updates and upgrades system packages via `apt-get`. Requires `sudo`. Runs `autoremove` and `autoclean` after upgrading. | Linux/WSL |
+| `fnm` | Checks the current Node.js version against the latest LTS. Installs and sets LTS as default on upgrade. | All |
+| `uv` | Runs `uv self update` (skipped if uv is brew-managed) and `uv tool upgrade --all`. | All |
+| `pipx` | Runs `pipx upgrade-all` to update all pipx-managed Python packages. | All |
+| `tpm` | Checks if TPM is installed. On upgrade, runs the TPM updater (`~/.tmux/plugins/tpm/bin/update_plugins all`). | All |
+| `vscode` | Counts installed VS Code extensions. On upgrade, re-installs each extension with `--force` to trigger updates. | All |
+| `chezmoi` | Checks for pending dotfile changes. On upgrade, runs `chezmoi update --force` to pull and apply from the repo. | All |
+
+### Module behavior
+
+- **status**: Each module checks for available updates and reports them. No changes are made.
+- **upgrade**: Each module applies its updates. A summary at the end shows which modules succeeded, failed, or were skipped.
+
+## Doctor
+
+`sysup doctor` reports system information, installed tools with versions, and key filesystem paths.
+
+### Tool groups
+
+| Group | Tools checked |
+|-------|--------------|
+| Package Managers | brew, apt-get, chezmoi, fnm, node, npm, uv, pipx |
+| Development Tools | git, zsh, tmux, fzf, docker, python3, poetry, just, gh, curl |
+| Modern CLI Replacements | eza, bat, fd, rg, delta, btop, zoxide, jq |
+
+### Key paths
+
+| Path | Description |
+|------|-------------|
+| `~/.tmux/plugins/tpm` | Tmux Plugin Manager |
+| `~/.oh-my-zsh` | Oh My Zsh framework |
+| `~/.config/dev/config` | Dev session manager config |
+| `~/Projects` | Project discovery directory |
+
+Each tool and path is shown with a green check or red cross indicating presence.
+
+## Typical Workflow
+
+```bash
+sysup              # What needs updating?
+sysup upgrade      # Update everything
+sysup doctor       # Verify all tools are present
+```
+
+## Adding a New Module (for contributors)
+
+Each module follows the same pattern:
+
+1. Create two functions: `<name>_status()` and `<name>_upgrade()`
+2. Gate both functions with `if ! has <tool>; then summary_skip "<name>"; return; fi`
+3. Use `summary_ok`, `summary_skip`, or `summary_fail` to report results
+4. Add calls to both functions in `cmd_status()` and `cmd_upgrade()`
+5. Add the tool to the appropriate `tools_*` array in `cmd_doctor()` so it appears in doctor output
+6. If the tool has a non-standard version flag, add a case to `get_version()`
+
+### Version detection
+
+The `get_version()` function handles tools with non-standard `--version` output. For most tools, it extracts just the version number. Add a new `case` entry if your tool's output format differs from `<tool> --version` printing a parseable version string.

--- a/dot_config/dev/config
+++ b/dot_config/dev/config
@@ -1,5 +1,5 @@
 # Dev session configuration
-# Format: project_name=layout[@host]
+# Format: project_name=layout[:path][@host]
 # Layouts: default, claude
 # Host: optional SSH hostname; omit for local projects
 #
@@ -14,3 +14,7 @@ default_layout=default
 # atomicguard=claude@myserver
 # manta-deploy=claude@myserver
 # c4ai-ml-agents=default
+
+# Custom-path projects (format: name=layout:path)
+# Dotfiles agent: Claude Code + shell in chezmoi source directory
+dotfiles=claude:~/.local/share/chezmoi

--- a/dot_local/bin/executable_dev
+++ b/dot_local/bin/executable_dev
@@ -51,7 +51,7 @@ config_get() {
 }
 
 # Get the layout for a project: check config, then default_layout, then "default".
-# Strips @host suffix if present.
+# Strips @host suffix and :path suffix if present.
 get_layout() {
   local project="$1"
   local raw
@@ -59,8 +59,9 @@ get_layout() {
   if [ -z "$raw" ]; then
     raw=$(config_get "default_layout")
   fi
-  # Strip @host if present
-  local layout="${raw%%@*}"
+  # Strip @host if present, then strip :path if present
+  local without_host="${raw%%@*}"
+  local layout="${without_host%%:*}"
   echo "${layout:-default}"
 }
 
@@ -71,6 +72,20 @@ get_host() {
   raw=$(config_get "$project")
   if [[ "$raw" == *@* ]]; then
     echo "${raw#*@}"
+  fi
+}
+
+# Get the custom path for a project. Returns empty if no custom path.
+get_path() {
+  local project="$1"
+  local raw
+  raw=$(config_get "$project")
+  [ -z "$raw" ] && return
+  # Strip @host if present, then check for :path
+  local without_host="${raw%%@*}"
+  if [[ "$without_host" == *:* ]]; then
+    local path_part="${without_host#*:}"
+    echo "${path_part/#\~/$HOME}"
   fi
 }
 
@@ -121,6 +136,19 @@ discover_projects() {
     fi
     echo -e "${display_name}\t${PROJECTS_DIR}/${rel_path}"
   done
+
+  # Append custom-path entries from config
+  if [ -f "$CONFIG_FILE" ]; then
+    while IFS='=' read -r key value; do
+      [[ "$key" =~ ^#.*$ || -z "$key" || "$key" == "default_layout" ]] && continue
+      local without_host="${value%%@*}"
+      if [[ "$without_host" == *:* ]]; then
+        local custom_path="${without_host#*:}"
+        custom_path="${custom_path/#\~/$HOME}"
+        [ -d "$custom_path" ] && echo -e "${key}\t${custom_path}"
+      fi
+    done < "$CONFIG_FILE"
+  fi
 }
 
 # Resolve a project name/pattern to a full path.
@@ -215,13 +243,24 @@ open_project() {
     return 0
   fi
 
-  # 3. Resolve local project path
+  # 3. Resolve local project path (check custom path first, then discover)
   local project_path
-  if ! project_path=$(resolve_project "$query"); then
+  local custom_path
+  custom_path=$(get_path "$query")
+  if [ -n "$custom_path" ]; then
+    [ -d "$custom_path" ] || die "Custom path for '$query' does not exist: $custom_path"
+    project_path="$custom_path"
+  elif ! project_path=$(resolve_project "$query"); then
     die "Project '$query' not found in $PROJECTS_DIR"
   fi
 
-  local session_name="${project_path##*/}"
+  # Use config key as session name for custom-path projects, otherwise basename
+  local session_name
+  if [ -n "$custom_path" ]; then
+    session_name="$query"
+  else
+    session_name="${project_path##*/}"
+  fi
 
   # 4. Also check resolved name for remote (in case query was fuzzy-matched)
   if [ "$session_name" != "$query" ]; then
@@ -555,10 +594,15 @@ CONFIGURATION
     atomicguard=claude@myserver
     manta-deploy=claude@myserver
     my-local-thing=default
+    dotfiles=claude:~/.local/share/chezmoi
 
-  Format: project=layout[@host]
+  Format: project=layout[:path][@host]
   - layout: default, claude
+  - :path:  optional custom directory (expands ~); omit for ~/Projects projects
   - @host:  optional SSH hostname; omit for local projects
+
+  Custom-path projects appear in the picker alongside ~/Projects entries
+  and use the config key as the session name.
 
 REMOTE PROJECTS
   If a project has @host in its config and the local hostname doesn't
@@ -572,6 +616,7 @@ INSIDE TMUX
 EXAMPLES
   dev                     # Pick from sessions/projects interactively
   dev atomicguard         # Open atomicguard with configured layout
+  dev dotfiles            # Open dotfiles in custom path (chezmoi dir)
   dev claude myproject    # Open myproject with claude+shell split
   dev kill myproject      # Kill myproject session
 EOF

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -184,6 +184,12 @@ _dev_completion() {
   subcmds=(claude detach kill kill-all help)
   sessions=(${(f)"$(tmux list-sessions -F '#S' 2>/dev/null)"})
   projects=(${(f)"$(/usr/bin/find ~/Projects -maxdepth 3 -name .git -type d 2>/dev/null | sed 's|.*/Projects/||;s|/\.git$||' | sort)"})
+  # Add custom-path projects from config
+  if [ -f ~/.config/dev/config ]; then
+    local -a config_projects
+    config_projects=(${(f)"$(grep -E '^[a-zA-Z].*=.*:' ~/.config/dev/config | cut -d= -f1)"})
+    projects+=($config_projects)
+  fi
   _arguments '1:command:->cmd' '2:target:->target'
   case $state in
     cmd) _describe 'command' subcmds -- sessions -- projects ;;


### PR DESCRIPTION
## Summary

- Add dotfiles agent: custom-path project config (`dotfiles=claude:~/.local/share/chezmoi`) with Claude Code permissions in `.claude/settings.json`
- Add `docs/dev.md`, `docs/sysup.md`, `docs/dotfiles-agent.md` with detailed usage references
- Trim CLAUDE.md back to lightweight form, replacing stale "Recent Changes" with docs links
- Update README.md structure tree, replace stale `tms`/`tmux-session` references with `dev` command, add Documentation section

**Stacks on:** #2

## Test plan

- [ ] `dev dotfiles` creates a claude+shell session in `~/.local/share/chezmoi`
- [ ] All doc links from README.md and CLAUDE.md resolve to existing files
- [ ] No duplicate content between CLAUDE.md and docs/
- [ ] `chezmoi apply --dry-run` deploys cleanly