### PR TITLE
Add testing infrastructure for dotfiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,9 @@ jobs:
         run: |
           sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
 
+      - name: Initialize chezmoi
+        run: chezmoi init --source=$PWD
+
       - name: Install jq
         run: sudo apt-get install -y jq
 
@@ -78,11 +81,14 @@ jobs:
       - name: Install chezmoi
         run: brew install chezmoi
 
+      - name: Initialize chezmoi
+        run: chezmoi init --source=$PWD
+
       - name: Install shellcheck
         run: brew install shellcheck
 
-      - name: Run template tests (darwin)
-        run: ./tests/test-templates.sh darwin
+      - name: Run template tests
+        run: ./tests/test-templates.sh
 
       - name: Run shellcheck on sysup
         run: shellcheck -x -s bash dot_local/bin/executable_sysup

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,6 @@ name: Test Dotfiles
 
 on:
   push:
-    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,25 +6,36 @@ on:
     branches: [main]
 
 jobs:
-  lint:
-    name: Shellcheck Lint
+  # ============================================================================
+  # Ubuntu Tests
+  # ============================================================================
+  ubuntu:
+    name: Ubuntu
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install shellcheck
-        run: sudo apt-get install -y shellcheck
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y shellcheck zsh jq
 
-      - name: Run shellcheck on sysup
+      - name: Install chezmoi
+        run: sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+
+      - name: Initialize chezmoi
+        run: chezmoi init --source=$PWD
+
+      # Shellcheck
+      - name: Shellcheck - sysup
         run: shellcheck -x -s bash dot_local/bin/executable_sysup
 
-      - name: Run shellcheck on dev
+      - name: Shellcheck - dev
         run: shellcheck -x -s bash dot_local/bin/executable_dev
 
-      - name: Run shellcheck on run_once scripts
+      - name: Shellcheck - run_once scripts
         run: |
-          # Only check pure shell scripts, not .tmpl files (Go templates confuse shellcheck)
           for script in run_once_*.sh; do
             if [[ -f "$script" && "$script" != *.tmpl ]]; then
               echo "Checking $script..."
@@ -32,66 +43,53 @@ jobs:
             fi
           done
 
-  templates-linux:
-    name: Template Validation (Linux)
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install chezmoi
-        run: |
-          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
-
-      - name: Initialize chezmoi
-        run: chezmoi init --source=$PWD
-
-      - name: Install jq
-        run: sudo apt-get install -y jq
-
-      - name: Run template tests
-        run: ./tests/test-templates.sh
-
-  syntax:
-    name: Syntax Checks
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install zsh
-        run: sudo apt-get install -y zsh
-
-      - name: Check zsh syntax
+      # Syntax checks
+      - name: Syntax - zshrc
         run: zsh -n dot_zshrc
 
-      - name: Check bash syntax on sysup
+      - name: Syntax - sysup
         run: bash -n dot_local/bin/executable_sysup
 
-      - name: Check bash syntax on dev
+      - name: Syntax - dev
         run: bash -n dot_local/bin/executable_dev
 
+      # Template validation
+      - name: Templates - validate all
+        run: ./tests/test-templates.sh
+
+  # ============================================================================
+  # macOS Tests
+  # ============================================================================
   macos:
-    name: macOS Tests
+    name: macOS
     runs-on: macos-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Install chezmoi
-        run: brew install chezmoi
+      - name: Install dependencies
+        run: brew install chezmoi shellcheck
 
       - name: Initialize chezmoi
         run: chezmoi init --source=$PWD
 
-      - name: Install shellcheck
-        run: brew install shellcheck
-
-      - name: Run template tests
-        run: ./tests/test-templates.sh
-
-      - name: Run shellcheck on sysup
+      # Shellcheck
+      - name: Shellcheck - sysup
         run: shellcheck -x -s bash dot_local/bin/executable_sysup
 
-      - name: Run shellcheck on dev
+      - name: Shellcheck - dev
         run: shellcheck -x -s bash dot_local/bin/executable_dev
+
+      # Syntax checks (zsh is pre-installed on macOS)
+      - name: Syntax - zshrc
+        run: zsh -n dot_zshrc
+
+      - name: Syntax - sysup
+        run: bash -n dot_local/bin/executable_sysup
+
+      - name: Syntax - dev
+        run: bash -n dot_local/bin/executable_dev
+
+      # Template validation
+      - name: Templates - validate all
+        run: ./tests/test-templates.sh

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,92 @@
+name: Test Dotfiles
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  lint:
+    name: Shellcheck Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get install -y shellcheck
+
+      - name: Run shellcheck on sysup
+        run: shellcheck -x -s bash dot_local/bin/executable_sysup
+
+      - name: Run shellcheck on dev
+        run: shellcheck -x -s bash dot_local/bin/executable_dev
+
+      - name: Run shellcheck on run_once scripts
+        run: |
+          # Only check pure shell scripts, not .tmpl files (Go templates confuse shellcheck)
+          for script in run_once_*.sh; do
+            if [[ -f "$script" && "$script" != *.tmpl ]]; then
+              echo "Checking $script..."
+              shellcheck -x -s bash "$script" || exit 1
+            fi
+          done
+
+  templates-linux:
+    name: Template Validation (Linux)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b /usr/local/bin
+
+      - name: Install jq
+        run: sudo apt-get install -y jq
+
+      - name: Run template tests
+        run: ./tests/test-templates.sh
+
+  syntax:
+    name: Syntax Checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install zsh
+        run: sudo apt-get install -y zsh
+
+      - name: Check zsh syntax
+        run: zsh -n dot_zshrc
+
+      - name: Check bash syntax on sysup
+        run: bash -n dot_local/bin/executable_sysup
+
+      - name: Check bash syntax on dev
+        run: bash -n dot_local/bin/executable_dev
+
+  macos:
+    name: macOS Tests
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install chezmoi
+        run: brew install chezmoi
+
+      - name: Install shellcheck
+        run: brew install shellcheck
+
+      - name: Run template tests (darwin)
+        run: ./tests/test-templates.sh darwin
+
+      - name: Run shellcheck on sysup
+        run: shellcheck -x -s bash dot_local/bin/executable_sysup
+
+      - name: Run shellcheck on dev
+        run: shellcheck -x -s bash dot_local/bin/executable_dev

--- a/dot_local/bin/executable_dev
+++ b/dot_local/bin/executable_dev
@@ -33,15 +33,13 @@ MAX_DEPTH=3
 
 if [ -t 1 ]; then
   BOLD='\033[1m'
-  DIM='\033[2m'
   RED='\033[0;31m'
   GREEN='\033[0;32m'
   YELLOW='\033[1;33m'
-  BLUE='\033[0;34m'
   CYAN='\033[1;36m'
   NC='\033[0m'
 else
-  BOLD='' DIM='' RED='' GREEN='' YELLOW='' BLUE='' CYAN='' NC=''
+  BOLD='' RED='' GREEN='' YELLOW='' CYAN='' NC=''
 fi
 
 # --- Helpers ------------------------------------------------------------------
@@ -126,7 +124,7 @@ discover_projects() {
   # Find all git repos up to MAX_DEPTH levels deep
   while IFS= read -r gitdir; do
     local project_path="${gitdir%/.git}"
-    local rel_path="${project_path#$PROJECTS_DIR/}"
+    local rel_path="${project_path#"$PROJECTS_DIR"/}"
     local name="${rel_path##*/}"
     entries+=("$rel_path")
     name_count[$name]=$(( ${name_count[$name]:-0} + 1 ))
@@ -295,7 +293,7 @@ open_project() {
 
 # Get formatted session info for display.
 format_sessions() {
-  tmux list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}|#{session_activity}' 2>/dev/null | while IFS='|' read -r name windows attached activity; do
+  tmux list-sessions -F '#{session_name}|#{session_windows}|#{session_attached}|#{session_activity}' 2>/dev/null | while IFS='|' read -r name _windows attached activity; do
     local status_info=""
     if [ "$attached" -gt 0 ]; then
       status_info="(attached)"
@@ -332,7 +330,7 @@ picker_fzf() {
 
   # Active sessions
   if tmux list-sessions &>/dev/null; then
-    while IFS='|' read -r name windows attached activity; do
+    while IFS='|' read -r name _windows attached activity; do
       local status_info=""
       if [ "$attached" -gt 0 ]; then
         status_info="(attached)"
@@ -445,7 +443,7 @@ picker_fallback() {
   # Active sessions
   if tmux list-sessions &>/dev/null; then
     echo -e "\n${BOLD} ACTIVE SESSIONS${NC}"
-    while IFS='|' read -r name windows attached activity; do
+    while IFS='|' read -r name _windows attached activity; do
       local status_info=""
       if [ "$attached" -gt 0 ]; then
         status_info="(attached)"

--- a/tests/test-templates.sh
+++ b/tests/test-templates.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+#
+# Template validation for chezmoi dotfiles
+#
+# Usage:
+#   ./tests/test-templates.sh           # Test with current platform
+#   ./tests/test-templates.sh darwin    # (informational only, uses actual OS)
+#   ./tests/test-templates.sh linux     # (informational only, uses actual OS)
+#
+# Note: Platform argument is informational only. Templates are rendered using
+# the actual system's chezmoi data. For cross-platform testing, use CI.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+pass() {
+    echo -e "  ${GREEN}✓${NC} $1"
+    ((pass_count++))
+}
+
+fail() {
+    echo -e "  ${RED}✗${NC} $1"
+    if [[ -n "${2:-}" ]]; then
+        echo -e "    ${RED}Error: $2${NC}"
+    fi
+    ((fail_count++))
+}
+
+skip() {
+    echo -e "  ${YELLOW}○${NC} $1 (skipped)"
+    ((skip_count++))
+}
+
+info() {
+    echo -e "  ${BLUE}→${NC} $1"
+}
+
+# Check if a command exists
+has_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Get current platform for display
+get_platform() {
+    case "$(uname -s)" in
+        Darwin) echo "darwin" ;;
+        Linux) echo "linux" ;;
+        *) echo "unknown" ;;
+    esac
+}
+
+# Test a single template file
+test_template() {
+    local template="$1"
+    local name
+    name=$(basename "$template")
+    local relative_path="${template#"$REPO_DIR/"}"
+
+    # Check if chezmoi is available
+    if ! has_cmd chezmoi; then
+        skip "$relative_path (chezmoi not installed)"
+        return 0
+    fi
+
+    # Create temp file for output
+    local output_file
+    output_file=$(mktemp)
+    local error_file
+    error_file=$(mktemp)
+
+    # Try to render the template using chezmoi execute-template
+    # Use --init to provide minimal chezmoi data for .chezmoi.toml.tmpl
+    local render_success=0
+    if chezmoi execute-template --init < "$template" > "$output_file" 2> "$error_file"; then
+        render_success=1
+    fi
+
+    if [[ $render_success -eq 0 ]]; then
+        local error_msg
+        error_msg=$(head -1 "$error_file")
+        fail "$relative_path (render failed)" "$error_msg"
+        rm -f "$output_file" "$error_file"
+        return 1
+    fi
+
+    # Additional validation based on file type
+    local validation_failed=0
+
+    # JSON validation
+    # Note: VS Code settings use JSONC (JSON with Comments), which jq can't parse.
+    # We skip JSON validation for VS Code settings files.
+    if [[ "$name" == *.json.tmpl && "$relative_path" != *"Code/User"* ]]; then
+        if has_cmd jq; then
+            if ! jq empty < "$output_file" 2>/dev/null; then
+                fail "$relative_path (invalid JSON)"
+                validation_failed=1
+            fi
+        else
+            info "$relative_path (jq not available for JSON validation)"
+        fi
+    fi
+
+    # SSH config validation
+    if [[ "$relative_path" == *"ssh/config"* ]]; then
+        if has_cmd ssh; then
+            # Create a temp SSH config and test it
+            local temp_ssh_config
+            temp_ssh_config=$(mktemp)
+            cat "$output_file" > "$temp_ssh_config"
+            if ! ssh -G -F "$temp_ssh_config" localhost >/dev/null 2>&1; then
+                fail "$relative_path (invalid SSH config)"
+                validation_failed=1
+            fi
+            rm -f "$temp_ssh_config"
+        else
+            info "$relative_path (ssh not available for config validation)"
+        fi
+    fi
+
+    # Shell script validation (rendered output)
+    if [[ "$name" == *.sh.tmpl ]]; then
+        if ! bash -n "$output_file" 2>/dev/null; then
+            fail "$relative_path (bash syntax error in rendered output)"
+            validation_failed=1
+        fi
+    fi
+
+    # Clean up
+    rm -f "$output_file" "$error_file"
+
+    if [[ $validation_failed -eq 0 ]]; then
+        pass "$relative_path"
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Find and test all templates
+test_all_templates() {
+    local failed=0
+
+    # Find all .tmpl files, excluding .git directory
+    local templates=()
+    while IFS= read -r -d '' template; do
+        templates+=("$template")
+    done < <(find "$REPO_DIR" -name "*.tmpl" -type f ! -path "*/.git/*" -print0 2>/dev/null)
+
+    if [[ ${#templates[@]} -eq 0 ]]; then
+        echo "No template files found"
+        return 0
+    fi
+
+    info "Found ${#templates[@]} template files"
+    echo ""
+
+    for template in "${templates[@]}"; do
+        if ! test_template "$template"; then
+            failed=1
+        fi
+    done
+
+    return $failed
+}
+
+# Print summary
+print_summary() {
+    echo -e "\n${BLUE}────────────────────────────────────────${NC}"
+    echo -e "  Passed:  ${GREEN}$pass_count${NC}"
+    if [[ $fail_count -gt 0 ]]; then
+        echo -e "  Failed:  ${RED}$fail_count${NC}"
+    else
+        echo -e "  Failed:  $fail_count"
+    fi
+    if [[ $skip_count -gt 0 ]]; then
+        echo -e "  Skipped: ${YELLOW}$skip_count${NC}"
+    else
+        echo -e "  Skipped: $skip_count"
+    fi
+    echo -e "${BLUE}────────────────────────────────────────${NC}\n"
+
+    if [[ $fail_count -gt 0 ]]; then
+        return 1
+    fi
+    return 0
+}
+
+# Main
+main() {
+    local platform
+    platform=$(get_platform)
+
+    echo -e "${BLUE}Template Validation${NC}"
+    echo -e "Platform: $platform"
+    echo ""
+
+    cd "$REPO_DIR"
+
+    local exit_code=0
+
+    if ! test_all_templates; then
+        exit_code=1
+    fi
+
+    print_summary || exit_code=1
+
+    exit $exit_code
+}
+
+main "$@"

--- a/tests/test-templates.sh
+++ b/tests/test-templates.sh
@@ -82,9 +82,12 @@ test_template() {
     error_file=$(mktemp)
 
     # Try to render the template using chezmoi execute-template
-    # Use --init to provide minimal chezmoi data for .chezmoi.toml.tmpl
+    # First try without --init (works if chezmoi is initialized)
+    # Fall back to --init for minimal data (covers .chezmoi.* but not .osid)
     local render_success=0
-    if chezmoi execute-template --init < "$template" > "$output_file" 2> "$error_file"; then
+    if chezmoi execute-template < "$template" > "$output_file" 2> "$error_file"; then
+        render_success=1
+    elif chezmoi execute-template --init < "$template" > "$output_file" 2> "$error_file"; then
         render_success=1
     fi
 

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+#
+# Local test runner for dotfiles repository
+#
+# Usage:
+#   ./tests/test.sh           # Run all tests
+#   ./tests/test.sh quick     # Lint + syntax only (no template rendering)
+#   ./tests/test.sh lint      # Shellcheck only
+#   ./tests/test.sh templates # Template tests only
+#   ./tests/test.sh syntax    # Syntax checks only
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+pass_count=0
+fail_count=0
+skip_count=0
+
+print_header() {
+    echo -e "\n${BLUE}══════════════════════════════════════════════════════════════${NC}"
+    echo -e "${BLUE}  $1${NC}"
+    echo -e "${BLUE}══════════════════════════════════════════════════════════════${NC}\n"
+}
+
+pass() {
+    echo -e "  ${GREEN}✓${NC} $1"
+    ((pass_count++))
+}
+
+fail() {
+    echo -e "  ${RED}✗${NC} $1"
+    ((fail_count++))
+}
+
+skip() {
+    echo -e "  ${YELLOW}○${NC} $1 (skipped)"
+    ((skip_count++))
+}
+
+info() {
+    echo -e "  ${BLUE}→${NC} $1"
+}
+
+# Check if a command exists
+has_cmd() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Run shellcheck on shell scripts
+run_lint() {
+    print_header "Shellcheck Lint"
+
+    if ! has_cmd shellcheck; then
+        skip "shellcheck not installed"
+        return 0
+    fi
+
+    local scripts=(
+        "$REPO_DIR/dot_local/bin/executable_sysup"
+        "$REPO_DIR/dot_local/bin/executable_dev"
+    )
+
+    # Add run_once scripts (only pure shell, not .tmpl - Go templates confuse shellcheck)
+    while IFS= read -r -d '' script; do
+        scripts+=("$script")
+    done < <(find "$REPO_DIR" -maxdepth 1 -name "run_once_*.sh" ! -name "*.tmpl" -print0 2>/dev/null || true)
+
+    local lint_failed=0
+    for script in "${scripts[@]}"; do
+        if [[ -f "$script" ]]; then
+            local name
+            name=$(basename "$script")
+            if shellcheck -x -s bash "$script" 2>/dev/null; then
+                pass "$name"
+            else
+                fail "$name"
+                lint_failed=1
+            fi
+        fi
+    done
+
+    return $lint_failed
+}
+
+# Run syntax checks
+run_syntax() {
+    print_header "Syntax Checks"
+
+    local syntax_failed=0
+
+    # Zsh syntax check
+    if has_cmd zsh; then
+        if [[ -f "$REPO_DIR/dot_zshrc" ]]; then
+            if zsh -n "$REPO_DIR/dot_zshrc" 2>/dev/null; then
+                pass "dot_zshrc (zsh -n)"
+            else
+                fail "dot_zshrc (zsh -n)"
+                syntax_failed=1
+            fi
+        fi
+    else
+        skip "zsh not installed"
+    fi
+
+    # Bash syntax check on shell scripts
+    local scripts=(
+        "$REPO_DIR/dot_local/bin/executable_sysup"
+        "$REPO_DIR/dot_local/bin/executable_dev"
+    )
+
+    for script in "${scripts[@]}"; do
+        if [[ -f "$script" ]]; then
+            local name
+            name=$(basename "$script")
+            if bash -n "$script" 2>/dev/null; then
+                pass "$name (bash -n)"
+            else
+                fail "$name (bash -n)"
+                syntax_failed=1
+            fi
+        fi
+    done
+
+    return $syntax_failed
+}
+
+# Run template tests
+run_templates() {
+    print_header "Template Validation"
+
+    if [[ -x "$SCRIPT_DIR/test-templates.sh" ]]; then
+        if "$SCRIPT_DIR/test-templates.sh"; then
+            pass "All templates validated"
+        else
+            fail "Template validation failed"
+            return 1
+        fi
+    else
+        skip "test-templates.sh not found or not executable"
+    fi
+
+    return 0
+}
+
+# Print summary
+print_summary() {
+    print_header "Summary"
+
+    local total=$((pass_count + fail_count + skip_count))
+    echo -e "  Total:   $total"
+    echo -e "  ${GREEN}Passed:  $pass_count${NC}"
+    if [[ $fail_count -gt 0 ]]; then
+        echo -e "  ${RED}Failed:  $fail_count${NC}"
+    else
+        echo -e "  Failed:  $fail_count"
+    fi
+    if [[ $skip_count -gt 0 ]]; then
+        echo -e "  ${YELLOW}Skipped: $skip_count${NC}"
+    else
+        echo -e "  Skipped: $skip_count"
+    fi
+    echo ""
+
+    if [[ $fail_count -gt 0 ]]; then
+        echo -e "${RED}Some tests failed!${NC}"
+        return 1
+    else
+        echo -e "${GREEN}All tests passed!${NC}"
+        return 0
+    fi
+}
+
+# Main
+main() {
+    local mode="${1:-all}"
+
+    echo -e "${BLUE}Dotfiles Test Runner${NC}"
+    echo -e "Mode: $mode"
+
+    cd "$REPO_DIR"
+
+    local exit_code=0
+
+    case "$mode" in
+        all)
+            run_lint || exit_code=1
+            run_syntax || exit_code=1
+            run_templates || exit_code=1
+            ;;
+        quick)
+            run_lint || exit_code=1
+            run_syntax || exit_code=1
+            ;;
+        lint)
+            run_lint || exit_code=1
+            ;;
+        syntax)
+            run_syntax || exit_code=1
+            ;;
+        templates)
+            run_templates || exit_code=1
+            ;;
+        *)
+            echo "Unknown mode: $mode"
+            echo "Usage: $0 [all|quick|lint|syntax|templates]"
+            exit 1
+            ;;
+    esac
+
+    print_summary || exit_code=1
+
+    exit $exit_code
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Add local test runner (`tests/test.sh`) for running tests locally
- Add GitHub Actions CI workflow with Ubuntu and macOS runners
- Fix shellcheck warnings in `executable_dev`

## What's tested

| Test | Ubuntu | macOS |
|------|--------|-------|
| Shellcheck (sysup, dev, run_once scripts) | ✓ | ✓ |
| Syntax checks (zshrc, sysup, dev) | ✓ | ✓ |
| Template validation | ✓ | ✓ |

## Local usage

```bash
./tests/test.sh           # Run all tests
./tests/test.sh quick     # Lint + syntax only
./tests/test.sh lint      # Shellcheck only
./tests/test.sh templates # Template tests only
```

## Test plan
- [x] Local tests pass: `./tests/test.sh`
- [x] CI workflow passes on Ubuntu
- [x] CI workflow passes on macOS