### PR TITLE
refactor(dev): add layout command to transform existing sessions

### DIFF
--- a/dot_local/bin/executable_dev
+++ b/dot_local/bin/executable_dev
@@ -193,6 +193,28 @@ resolve_project() {
 
 # --- Session Management ------------------------------------------------------
 
+# Apply layout to current tmux session (must be inside tmux)
+apply_layout() {
+  local layout="$1"
+
+  case "$layout" in
+    claude)
+      # Split current pane: new pane on left, current stays on right
+      # -h = horizontal split (side by side)
+      # -b = put new pane before (left of) current
+      # -c = use current pane's path
+      tmux split-window -hb -c "#{pane_current_path}"
+      # Run claude in the new (left) pane
+      tmux send-keys 'claude' Enter
+      # Focus back to the right pane (shell)
+      tmux select-pane -R
+      ;;
+    *)
+      die "Unknown layout: $layout"
+      ;;
+  esac
+}
+
 # Create a new tmux session with the given layout.
 create_session() {
   local session_name="$1"
@@ -578,6 +600,7 @@ USAGE
   dev                     Interactive picker (fzf or numbered fallback)
   dev <project>           Create or attach to session for <project>
   dev claude <project>    Force claude+shell layout (vertical split)
+  dev layout [name]       Show or change layout (claude = add claude pane)
   dev detach              Detach from current tmux session
   dev kill <name>         Kill a session
   dev kill-all            Kill all sessions (with confirmation)
@@ -681,6 +704,25 @@ main() {
       local project="${2:-}"
       [ -n "$project" ] || die "Usage: dev claude <project>"
       open_project "$project" "claude"
+      ;;
+    layout)
+      if [ -z "${TMUX:-}" ]; then
+        die "Not inside a tmux session. Use 'dev claude <project>' to create a new session."
+      fi
+      local layout_name="${2:-}"
+      if [ -z "$layout_name" ]; then
+        # No layout specified - show current pane info
+        local pane_count
+        pane_count=$(tmux list-panes | wc -l | tr -d ' ')
+        if [ "$pane_count" -ge 2 ]; then
+          info "Current layout: claude+shell ($pane_count panes)"
+        else
+          info "Current layout: default (1 pane)"
+          echo "  Use 'dev layout claude' to split"
+        fi
+        return 0
+      fi
+      apply_layout "$layout_name"
       ;;
     *)
       open_project "$1"

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -181,7 +181,7 @@ setopt ALWAYS_TO_END
 # dev command completion
 _dev_completion() {
   local -a subcmds sessions projects
-  subcmds=(claude detach kill kill-all help)
+  subcmds=(claude layout detach kill kill-all help)
   sessions=(${(f)"$(tmux list-sessions -F '#S' 2>/dev/null)"})
   projects=(${(f)"$(/usr/bin/find ~/Projects -maxdepth 3 -name .git -type d 2>/dev/null | sed 's|.*/Projects/||;s|/\.git$||' | sort)"})
   # Add custom-path projects from config


### PR DESCRIPTION
## Summary
- Add `dev layout` command to show current pane count and layout info
- Add `dev layout claude` to split an existing single-pane session into claude+shell layout
- Add shell completion for the new `layout` subcommand

## Test plan
- [ ] Start a default session: `dev <project>`
- [ ] Run `dev layout` → should show "Current layout: default (1 pane)"
- [ ] Run `dev layout claude` from inside the session
- [ ] Verify: left pane has claude running, right pane is shell, focus is on shell
- [ ] Run `dev layout` again → should show "Current layout: claude+shell (2 panes)"
- [ ] Test error case: run `dev layout claude` outside tmux → should show helpful error