### PR TITLE
feat: CPU temperature, CPU hog, and pop-upgrade monitoring (#17)

### DIFF
--- a/dot_local/bin/executable_sysmon
+++ b/dot_local/bin/executable_sysmon
@@ -257,6 +257,22 @@ get_top_procs_cpu() {
   ps -eo pid,user,%cpu,%mem,comm 2>/dev/null | sort -k3 -rn | awk -v n="$count" 'NR<=n'
 }
 
+# Linux-only: returns integer °C from lm-sensors, or empty string if unavailable
+get_cpu_temp() {
+  [ "$IS_LINUX" = true ] || return
+  has sensors || return
+  # AMD k10temp uses Tctl, Intel coretemp uses "Package id 0"
+  sensors 2>/dev/null | awk '
+    /^Tctl:|^Package id 0:/ {
+      if (match($0, /\+[0-9]+/)) {
+        val = substr($0, RSTART+1, RLENGTH-1)+0
+        if (val > t) t = val
+      }
+    }
+    END { if (t > 0) print t }
+  '
+}
+
 # Top processes by memory: prints "pid user cpu% mem% rss command"
 get_top_procs_mem() {
   local count="${1:-5}"
@@ -352,6 +368,45 @@ add_warning() {
   fi
 }
 
+check_temps() {
+  [ "$IS_LINUX" = true ] || return
+  local cpu_temp
+  cpu_temp=$(get_cpu_temp)
+  [ -n "$cpu_temp" ] || return
+  if [ "$cpu_temp" -ge 90 ]; then
+    add_warning "critical" "CPU temperature at ${cpu_temp}°C (threshold 90°C)"
+  elif [ "$cpu_temp" -ge 75 ]; then
+    add_warning "warn" "CPU temperature at ${cpu_temp}°C (threshold 75°C)"
+  fi
+}
+
+check_cpu_hogs() {
+  [ "$IS_LINUX" = true ] || return
+  local clk_tck
+  clk_tck=$(getconf CLK_TCK 2>/dev/null || echo "100")
+
+  while read -r pid user cpu _mem comm; do
+    [ -n "$cpu" ] || continue
+    # Any process >50% CPU right now
+    if awk "BEGIN {exit !($cpu >= 50)}"; then
+      add_warning "warn" "Process '$comm' (PID $pid, $user) using ${cpu}% CPU"
+      continue
+    fi
+    # Root daemons >10% CPU with >1h accumulated time (runaway pattern)
+    if [ "$user" = "root" ] && awk "BEGIN {exit !($cpu >= 10)}"; then
+      if [ -f "/proc/$pid/stat" ]; then
+        local utime stime cpu_hours
+        utime=$(awk '{print $14}' "/proc/$pid/stat" 2>/dev/null || echo 0)
+        stime=$(awk '{print $15}' "/proc/$pid/stat" 2>/dev/null || echo 0)
+        cpu_hours=$(( (utime + stime) / clk_tck / 3600 ))
+        if [ "$cpu_hours" -ge 1 ]; then
+          add_warning "warn" "Root daemon '$comm' (PID $pid) using ${cpu}% CPU, ${cpu_hours}h accumulated (consider: sudo systemctl restart $comm)"
+        fi
+      fi
+    fi
+  done < <(get_top_procs_cpu 10)
+}
+
 check_warnings() {
   WARN_COUNT=0
   CRIT_COUNT=0
@@ -409,6 +464,9 @@ check_warnings() {
     add_warning "warn" "$zombie_count zombie process(es) detected"
   fi
 
+  check_temps
+  check_cpu_hogs
+
   # Backup staleness (if sysbak is available)
   if has sysbak; then
     local bak_output bak_exit=0
@@ -436,6 +494,14 @@ cmd_status() {
   local cores
   cores=$(get_cpu_count)
   printf "  %-10s %s  (%s cores)\n" "Load:" "$(get_load_avg)" "$cores"
+  local cpu_temp
+  cpu_temp=$(get_cpu_temp)
+  if [ -n "$cpu_temp" ]; then
+    local temp_color="${GREEN}"
+    [ "$cpu_temp" -ge 75 ] && temp_color="${YELLOW}"
+    [ "$cpu_temp" -ge 90 ] && temp_color="${RED}"
+    printf "  %-10s ${temp_color}%s°C${NC}\n" "CPU temp:" "$cpu_temp"
+  fi
 
   # Memory
   header "Memory"
@@ -762,6 +828,8 @@ HEALTH CHECKS (sysmon warn)
   Swap usage          warn >50%, critical >80%
   Load average        warn >cores, critical >cores×2
   Zombie processes    warn >0, critical >5
+  CPU temperature     warn >75°C, critical >90°C (Linux, requires lm-sensors)
+  CPU hogs            warn if any process >50% CPU, or root daemon >10% CPU for >1h
 
 EXAMPLES
   sysmon              # Quick health dashboard

--- a/dot_local/bin/executable_sysmon
+++ b/dot_local/bin/executable_sysmon
@@ -259,8 +259,8 @@ get_top_procs_cpu() {
 
 # Linux-only: returns integer °C from lm-sensors, or empty string if unavailable
 get_cpu_temp() {
-  [ "$IS_LINUX" = true ] || return
-  has sensors || return
+  [ "$IS_LINUX" = true ] || return 0
+  has sensors || return 0
   # AMD k10temp uses Tctl, Intel coretemp uses "Package id 0"
   sensors 2>/dev/null | awk '
     /^Tctl:|^Package id 0:/ {
@@ -369,10 +369,10 @@ add_warning() {
 }
 
 check_temps() {
-  [ "$IS_LINUX" = true ] || return
+  [ "$IS_LINUX" = true ] || return 0
   local cpu_temp
   cpu_temp=$(get_cpu_temp)
-  [ -n "$cpu_temp" ] || return
+  [ -n "$cpu_temp" ] || return 0
   if [ "$cpu_temp" -ge 90 ]; then
     add_warning "critical" "CPU temperature at ${cpu_temp}°C (threshold 90°C)"
   elif [ "$cpu_temp" -ge 75 ]; then
@@ -381,7 +381,7 @@ check_temps() {
 }
 
 check_cpu_hogs() {
-  [ "$IS_LINUX" = true ] || return
+  [ "$IS_LINUX" = true ] || return 0
   local clk_tck
   clk_tck=$(getconf CLK_TCK 2>/dev/null || echo "100")
 

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -434,7 +434,7 @@ cmd_doctor() {
   done
 
   header "Modern CLI Replacements"
-  local tools_cli=(eza bat fd rg delta btop zoxide jq)
+  local tools_cli=(eza bat fd rg delta btop zoxide jq sensors sar)
   for tool in "${tools_cli[@]}"; do
     check_tool "$tool"
   done
@@ -445,14 +445,35 @@ cmd_doctor() {
   check_path "$HOME/.config/dev/config" "dev config"
   check_path "$HOME/.config/sysbak/config" "sysbak config"
   check_path "$HOME/Projects" "Projects directory"
+
+  # Linux-specific daemon health
+  if [ "$IS_LINUX" = true ] && has pop-upgrade; then
+    header "Linux Daemon Health"
+    local pu_pid pu_cpu
+    pu_pid=$(pgrep -x pop-upgrade 2>/dev/null | head -1)
+    if [ -n "$pu_pid" ]; then
+      pu_cpu=$(ps -p "$pu_pid" -o %cpu= 2>/dev/null | tr -d ' ')
+      if awk "BEGIN {exit !($pu_cpu > 5)}"; then
+        echo -e "  ${YELLOW}⚠${NC}  pop-upgrade  ${YELLOW}${pu_cpu}% CPU (stuck? sudo systemctl restart pop-upgrade)${NC}"
+      else
+        echo -e "  ${GREEN}✓${NC}  pop-upgrade  ${GREEN}idle (${pu_cpu}% CPU)${NC}"
+      fi
+    else
+      echo -e "  ${DIM}-${NC}  pop-upgrade  ${DIM}not running${NC}"
+    fi
+  fi
 }
 
 check_tool() {
   local tool="$1"
   if has "$tool"; then
     local version
-    version=$(get_version "$tool")
-    printf "  ${GREEN}✓${NC} %-14s %s\n" "$tool" "$version"
+    version=$(get_version "$tool" 2>/dev/null) || true
+    if [ -n "$version" ]; then
+      printf "  ${GREEN}✓${NC} %-14s %s\n" "$tool" "$version"
+    else
+      printf "  ${YELLOW}⚠${NC} %-14s %s\n" "$tool" "installed (version unavailable)"
+    fi
   else
     printf "  ${RED}✗${NC} %-14s %s\n" "$tool" "not installed"
   fi
@@ -489,6 +510,8 @@ get_version() {
     apt-get)   apt-get --version 2>/dev/null | head -1 | awk '{print $2}' ;;
     sysbak)    sysbak version 2>/dev/null ;;
     rsnapshot) rsnapshot --version 2>&1 | head -1 ;;
+    sensors)   sensors -v 2>/dev/null | awk '{print $3}' ;;
+    sar)       sar -V 2>/dev/null | awk '{print $3}' ;;
     *)         "$tool" --version 2>/dev/null | head -1 ;;
   esac
 }

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -68,9 +68,9 @@ is_wsl() {
 {{ if eq .osid "linux-debian" "linux-raspbian" "linux-pop" "linux-ubuntu" -}}
 echo '🐧 Installing Linux packages'
 
-{{ $linuxSpecific := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" -}}
-{{ $linuxWithDocker := list "python3" "python3-pip" "fontconfig" "docker.io" "openssh-client" "docker-compose-plugin" "gpg" -}}
-{{ $linuxWithoutDocker := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" -}}
+{{ $linuxSpecific := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" -}}
+{{ $linuxWithDocker := list "python3" "python3-pip" "fontconfig" "docker.io" "openssh-client" "docker-compose-plugin" "gpg" "lm-sensors" "sysstat" -}}
+{{ $linuxWithoutDocker := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" -}}
 {{ $sudo := "sudo " -}}
 {{ if eq .chezmoi.username "root" -}}
 {{   $sudo = "" -}}


### PR DESCRIPTION
## Summary

Motivated by a `pop-upgrade` daemon that ran at 20.6% CPU for 10 days undetected, driving the CPU to 85°C. `sysmon warn` missed it entirely.

- **`sysmon`**: temperature monitoring (lm-sensors, AMD + Intel), CPU hog detection (>50% instant or root daemon >10% for >1h), CPU temp shown in `sysmon status`
- **`sysup doctor`**: `sensors`/`sar` added to tool inventory; pop-upgrade health check (Linux-only); crash fix — broken tools (e.g. poetry with missing libpython) now show a warning instead of aborting the doctor run under `set -euo pipefail`
- **`run_once_install-packages.sh.tmpl`**: `lm-sensors` and `sysstat` added to all Linux package lists

## Changes

| File | Change |
|------|--------|
| `executable_sysmon` | `get_cpu_temp()`, `check_temps()`, `check_cpu_hogs()`, temp in `cmd_status()` |
| `executable_sysup` | `sensors`/`sar` in `tools_cli`, pop-upgrade daemon check, `check_tool()` crash fix |
| `run_once_install-packages.sh.tmpl` | `lm-sensors`, `sysstat` in Linux packages |

## Test plan

- [x] `./tests/test.sh quick` — shellcheck + syntax pass (10/10)
- [x] `sysmon warn` — runs without error when `sensors` absent (graceful skip)
- [x] `sysmon status` — shows `CPU temp: 44°C` line when `sensors` available
- [x] `sysmon warn` — detected active CPU hog (ruby at 52.7%)
- [x] `sysup doctor` — runs to completion (previously crashed on broken poetry install)
- [x] `sysup doctor` — shows `sensors 3.6.0`, `sar not installed`, `pop-upgrade idle`
- [x] `chezmoi apply --dry-run` — deploys cleanly