### PR TITLE
feat: add LiteLLM proxy as a managed service

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,9 @@ jobs:
       - name: Shellcheck - sysbak
         run: shellcheck -x -s bash dot_local/bin/executable_sysbak
 
+      - name: Shellcheck - litellm
+        run: shellcheck -x -s bash dot_local/bin/executable_litellm
+
       - name: Shellcheck - run_once scripts
         run: |
           for script in run_once_*.sh; do
@@ -64,6 +67,9 @@ jobs:
 
       - name: Syntax - sysbak
         run: bash -n dot_local/bin/executable_sysbak
+
+      - name: Syntax - litellm
+        run: bash -n dot_local/bin/executable_litellm
 
       # Template validation
       - name: Templates - validate all
@@ -102,6 +108,9 @@ jobs:
       - name: Shellcheck - sysbak
         run: shellcheck -x -s bash dot_local/bin/executable_sysbak
 
+      - name: Shellcheck - litellm
+        run: shellcheck -x -s bash dot_local/bin/executable_litellm
+
       # Syntax checks (zsh is pre-installed on macOS)
       - name: Syntax - zshrc
         run: zsh -n dot_zshrc
@@ -117,6 +126,9 @@ jobs:
 
       - name: Syntax - sysbak
         run: bash -n dot_local/bin/executable_sysbak
+
+      - name: Syntax - litellm
+        run: bash -n dot_local/bin/executable_litellm
 
       # Template validation
       - name: Templates - validate all

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ The zsh configuration uses these variables:
 ### System Maintenance
 - `dot_local/bin/executable_sysup`: Cross-platform system update utility (status, upgrade, doctor)
 - `dot_local/bin/executable_sysmon`: Cross-platform system health monitor (status, disk, mem, proc, net, warn)
+- `dot_local/bin/executable_litellm`: LiteLLM proxy wrapper (start, stop, status, config, models, setup)
 
 ### Backup
 - `dot_local/bin/executable_sysbak`: Cross-platform USB rsnapshot backup manager (status, list, diff, restore, warn)
@@ -155,6 +156,7 @@ Detailed usage guides are in `docs/`:
 - [`docs/sysup.md`](docs/sysup.md) — System update utility reference
 - [`docs/sysmon.md`](docs/sysmon.md) — System health monitor reference
 - [`docs/sysbak.md`](docs/sysbak.md) — Backup manager reference
+- [`docs/litellm.md`](docs/litellm.md) — LiteLLM proxy wrapper reference
 - [`docs/dotfiles-agent.md`](docs/dotfiles-agent.md) — Dotfiles agent setup and usage
 
 ## When Making Changes

--- a/docs/litellm.md
+++ b/docs/litellm.md
@@ -1,0 +1,114 @@
+# LiteLLM Proxy (litellm)
+
+`litellm` is a wrapper around [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) that provides a unified OpenAI-compatible API endpoint for multiple LLM providers (Anthropic, OpenAI, Ollama, etc.). It manages the proxy lifecycle, configuration, and service integration.
+
+**Source:** `~/.local/bin/litellm` (`dot_local/bin/executable_litellm` in chezmoi)
+
+## Synopsis
+
+```bash
+litellm                     # Show proxy status (same as litellm status)
+litellm start               # Start the proxy server (foreground)
+litellm status              # Show whether the proxy is running
+litellm stop                # Stop the proxy server
+litellm restart             # Restart the proxy server
+litellm config              # Show configuration file
+litellm models              # List configured models
+litellm setup               # Install litellm and create default config
+litellm version             # Show litellm version
+litellm help                # Show built-in help
+```
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `litellm` / `litellm status` | Show binary version, config path, port, process status, service state |
+| `litellm start` | Start the proxy in foreground. Use `--service` for systemd/launchd |
+| `litellm stop` | Stop the proxy (tries systemd/launchd first, falls back to kill-by-port) |
+| `litellm restart` | Restart the proxy (service manager or manual stop+start) |
+| `litellm config` | Print config file. `--edit` opens in `$EDITOR`. `--validate` checks YAML |
+| `litellm models` | List model names from config |
+| `litellm setup` | Install litellm, create config/env, enable service |
+| `litellm version` | Print the litellm version |
+| `litellm help` | Show built-in help text |
+
+## Configuration
+
+### Config File
+
+`~/.config/litellm/config.yaml` — LiteLLM proxy configuration with model definitions.
+
+The default config includes models for Anthropic (Claude Sonnet, Claude Haiku), OpenAI (GPT-4o, GPT-4o-mini), and Ollama (Llama 3). API keys are referenced via `os.environ/` so they're read from environment variables at runtime.
+
+### Environment File
+
+`~/.config/litellm/env` — API keys and environment variables. Created with mode `600` by `litellm setup`. This file is loaded by the systemd service (`EnvironmentFile`) and should contain:
+
+```bash
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+```
+
+### Port and Host
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `$LITELLM_PORT` | `4000` | Port for the proxy server |
+| `$LITELLM_HOST` | `0.0.0.0` | Host to bind to (0.0.0.0 = all interfaces) |
+
+## Service Management
+
+### Linux (systemd)
+
+The systemd user service is deployed to `~/.config/systemd/user/litellm-proxy.service`.
+
+```bash
+systemctl --user enable litellm-proxy   # Enable on login
+systemctl --user start litellm-proxy    # Start now
+systemctl --user stop litellm-proxy     # Stop
+systemctl --user status litellm-proxy   # Check status
+journalctl --user -u litellm-proxy -f   # Follow logs
+```
+
+### macOS (launchd)
+
+A LaunchAgent plist is created by `litellm setup` at `~/Library/LaunchAgents/com.user.litellm-proxy.plist`.
+
+```bash
+launchctl load ~/Library/LaunchAgents/com.user.litellm-proxy.plist    # Load
+launchctl unload ~/Library/LaunchAgents/com.user.litellm-proxy.plist  # Unload
+```
+
+Logs go to `~/.local/share/litellm/proxy.log`.
+
+## API Usage
+
+Once running, the proxy provides an OpenAI-compatible API:
+
+```bash
+# List available models
+curl http://localhost:4000/v1/models
+
+# Chat completion
+curl http://localhost:4000/v1/chat/completions \
+  -H "Content-Type: application/json" \
+  -d '{"model": "claude-sonnet", "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+Any OpenAI SDK-compatible client can point to `http://localhost:4000` as the base URL.
+
+## Integration
+
+- **sysmon**: Shows LiteLLM listening status in the Services section
+- **sysup doctor**: Checks for litellm binary and config file
+- **Welcome message**: Shows `litellm [start]` in available commands
+
+## First-Time Setup
+
+```bash
+litellm setup              # Install binary, create config and env
+$EDITOR ~/.config/litellm/env    # Add your API keys
+litellm start              # Test in foreground
+litellm models             # Verify models loaded
+```

--- a/dot_config/litellm/create_config.yaml
+++ b/dot_config/litellm/create_config.yaml
@@ -1,0 +1,38 @@
+# LiteLLM Proxy Configuration
+# https://docs.litellm.ai/docs/proxy/configs
+#
+# API keys are read from environment variables via os.environ/.
+# Set them in ~/.config/litellm/env or export them in your shell.
+
+model_list:
+  # Anthropic
+  - model_name: claude-sonnet
+    litellm_params:
+      model: anthropic/claude-sonnet-4-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-haiku
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # OpenAI
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  # Ollama (local)
+  - model_name: llama3
+    litellm_params:
+      model: ollama/llama3
+      api_base: http://localhost:11434
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false

--- a/dot_config/systemd/user/litellm-proxy.service
+++ b/dot_config/systemd/user/litellm-proxy.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=LiteLLM Proxy - unified LLM API gateway
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+ExecStart=%h/.local/bin/litellm start --service
+EnvironmentFile=-%h/.config/litellm/env
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/dot_local/bin/executable_litellm
+++ b/dot_local/bin/executable_litellm
@@ -1,0 +1,543 @@
+#!/bin/bash
+# ============================================================================
+# litellm - LiteLLM proxy wrapper
+# ============================================================================
+# Manages a LiteLLM proxy server that provides a unified OpenAI-compatible
+# API endpoint for multiple LLM providers (Anthropic, OpenAI, Ollama, etc.).
+#
+# Usage: litellm [command]
+#   litellm              Show proxy status (same as litellm status)
+#   litellm start        Start the proxy server (foreground)
+#   litellm status       Show whether the proxy is running
+#   litellm stop         Stop the proxy server
+#   litellm restart      Restart the proxy server
+#   litellm config       Show configuration file
+#   litellm models       List configured models
+#   litellm setup        Install litellm and create default config
+#   litellm help         Show usage text
+
+set -euo pipefail
+
+# --- Colors (guarded for pipe safety) ----------------------------------------
+
+if [ -t 1 ]; then
+  BOLD='\033[1m'
+  DIM='\033[2m'
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[1;33m'
+  BLUE='\033[0;34m'
+  CYAN='\033[1;36m'
+  NC='\033[0m'
+else
+  BOLD='' DIM='' RED='' GREEN='' YELLOW='' BLUE='' CYAN='' NC=''
+fi
+
+# --- Helpers ------------------------------------------------------------------
+
+die()     { echo -e "${RED}Error: $*${NC}" >&2; exit 1; }
+info()    { echo -e "${CYAN}$*${NC}"; }
+warn()    { echo -e "${YELLOW}$*${NC}"; }
+success() { echo -e "${GREEN}$*${NC}"; }
+header()  { echo -e "\n${BOLD}${BLUE}── $* ──${NC}"; }
+
+has() { command -v "$1" &>/dev/null; }
+
+# --- Platform Detection -------------------------------------------------------
+
+IS_WSL=false
+IS_MACOS=false
+IS_LINUX=false
+
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  IS_MACOS=true
+elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
+  IS_WSL=true
+else
+  IS_LINUX=true
+fi
+
+# --- Configuration ------------------------------------------------------------
+
+CONFIG_DIR="${XDG_CONFIG_HOME:-$HOME/.config}/litellm"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+ENV_FILE="$CONFIG_DIR/env"
+DEFAULT_PORT="${LITELLM_PORT:-4000}"
+DEFAULT_HOST="${LITELLM_HOST:-0.0.0.0}"
+LAUNCHD_LABEL="com.user.litellm-proxy"
+LAUNCHD_PLIST="$HOME/Library/LaunchAgents/${LAUNCHD_LABEL}.plist"
+
+# --- Port Detection -----------------------------------------------------------
+
+# Check if a process is listening on the configured port
+is_port_listening() {
+  if [ "$IS_MACOS" = true ]; then
+    lsof -i ":$DEFAULT_PORT" -P -n 2>/dev/null | grep -q LISTEN
+  else
+    ss -tln 2>/dev/null | grep -q ":${DEFAULT_PORT} "
+  fi
+}
+
+# Get PID of process on the configured port
+get_port_pid() {
+  if [ "$IS_MACOS" = true ]; then
+    lsof -i ":$DEFAULT_PORT" -P -n -t 2>/dev/null | head -1
+  else
+    ss -tlnp 2>/dev/null | awk -v port=":${DEFAULT_PORT} " '$4 ~ port {match($0,/pid=([0-9]+)/,m); print m[1]}' | head -1
+  fi
+}
+
+# === Subcommands ==============================================================
+
+# --- start --------------------------------------------------------------------
+
+cmd_start() {
+  local service_mode=false
+  for arg in "$@"; do
+    case "$arg" in
+      --service) service_mode=true ;;
+    esac
+  done
+
+  has litellm || die "litellm not found. Run 'litellm setup' to install."
+  [ -f "$CONFIG_FILE" ] || die "Config not found: $CONFIG_FILE\nRun 'litellm setup' to create default config."
+
+  if is_port_listening; then
+    local pid
+    pid=$(get_port_pid)
+    die "Port $DEFAULT_PORT already in use (PID ${pid:-unknown}). Run 'litellm stop' first."
+  fi
+
+  if [ "$service_mode" = false ]; then
+    info "Starting LiteLLM proxy on ${DEFAULT_HOST}:${DEFAULT_PORT}"
+    echo -e "${DIM}Config: $CONFIG_FILE${NC}"
+    echo -e "${DIM}Press Ctrl+C to stop${NC}"
+    echo ""
+  fi
+
+  exec litellm --config "$CONFIG_FILE" --port "$DEFAULT_PORT" --host "$DEFAULT_HOST"
+}
+
+# --- status -------------------------------------------------------------------
+
+cmd_status() {
+  header "LiteLLM Proxy"
+
+  # Binary
+  if has litellm; then
+    local version
+    version=$(litellm --version 2>/dev/null | head -1 || echo "unknown")
+    printf "  %-12s ${GREEN}installed${NC} (%s)\n" "Binary:" "$version"
+  else
+    printf "  %-12s ${RED}not installed${NC}\n" "Binary:"
+  fi
+
+  # Config
+  if [ -f "$CONFIG_FILE" ]; then
+    printf "  %-12s %s\n" "Config:" "$CONFIG_FILE"
+  else
+    printf "  %-12s ${DIM}not found${NC}\n" "Config:"
+  fi
+
+  # Port
+  printf "  %-12s %s\n" "Port:" "$DEFAULT_PORT"
+
+  # Process
+  if is_port_listening; then
+    local pid
+    pid=$(get_port_pid)
+    printf "  %-12s ${GREEN}listening${NC} (PID %s)\n" "Status:" "${pid:-?}"
+  else
+    printf "  %-12s ${DIM}stopped${NC}\n" "Status:"
+  fi
+
+  # Service manager
+  if [ "$IS_LINUX" = true ] || [ "$IS_WSL" = true ]; then
+    if has systemctl; then
+      local svc_state
+      svc_state=$(systemctl --user is-active litellm-proxy 2>/dev/null || echo "inactive")
+      local svc_enabled
+      svc_enabled=$(systemctl --user is-enabled litellm-proxy 2>/dev/null || echo "disabled")
+      printf "  %-12s %s (%s)\n" "Service:" "$svc_state" "$svc_enabled"
+    fi
+  elif [ "$IS_MACOS" = true ]; then
+    if [ -f "$LAUNCHD_PLIST" ]; then
+      if launchctl list "$LAUNCHD_LABEL" &>/dev/null; then
+        printf "  %-12s ${GREEN}loaded${NC}\n" "LaunchAgent:"
+      else
+        printf "  %-12s ${DIM}unloaded${NC}\n" "LaunchAgent:"
+      fi
+    else
+      printf "  %-12s ${DIM}not installed${NC}\n" "LaunchAgent:"
+    fi
+  fi
+
+  # Models
+  if [ -f "$CONFIG_FILE" ]; then
+    local model_count
+    model_count=$(awk '/model_name:/' "$CONFIG_FILE" | wc -l | tr -d ' ')
+    printf "  %-12s %s configured\n" "Models:" "$model_count"
+  fi
+}
+
+# --- stop ---------------------------------------------------------------------
+
+cmd_stop() {
+  # Try service manager first
+  if [ "$IS_LINUX" = true ] || [ "$IS_WSL" = true ]; then
+    if has systemctl; then
+      local svc_state
+      svc_state=$(systemctl --user is-active litellm-proxy 2>/dev/null || echo "inactive")
+      if [ "$svc_state" = "active" ]; then
+        info "Stopping via systemd..."
+        systemctl --user stop litellm-proxy
+        success "Stopped litellm-proxy service"
+        return 0
+      fi
+    fi
+  elif [ "$IS_MACOS" = true ]; then
+    if [ -f "$LAUNCHD_PLIST" ] && launchctl list "$LAUNCHD_LABEL" &>/dev/null; then
+      info "Stopping via launchd..."
+      launchctl unload "$LAUNCHD_PLIST"
+      success "Stopped litellm-proxy LaunchAgent"
+      return 0
+    fi
+  fi
+
+  # Fall back to kill by port
+  if is_port_listening; then
+    local pid
+    pid=$(get_port_pid)
+    if [ -n "$pid" ]; then
+      info "Stopping PID $pid on port $DEFAULT_PORT..."
+      kill "$pid"
+      success "Stopped litellm proxy (PID $pid)"
+    else
+      die "Cannot determine PID for port $DEFAULT_PORT"
+    fi
+  else
+    warn "LiteLLM proxy is not running on port $DEFAULT_PORT"
+  fi
+}
+
+# --- restart ------------------------------------------------------------------
+
+cmd_restart() {
+  # Try service manager first
+  if [ "$IS_LINUX" = true ] || [ "$IS_WSL" = true ]; then
+    if has systemctl; then
+      local svc_state
+      svc_state=$(systemctl --user is-active litellm-proxy 2>/dev/null || echo "inactive")
+      if [ "$svc_state" = "active" ]; then
+        info "Restarting via systemd..."
+        systemctl --user restart litellm-proxy
+        success "Restarted litellm-proxy service"
+        return 0
+      fi
+    fi
+  elif [ "$IS_MACOS" = true ]; then
+    if [ -f "$LAUNCHD_PLIST" ] && launchctl list "$LAUNCHD_LABEL" &>/dev/null; then
+      info "Restarting via launchd..."
+      launchctl unload "$LAUNCHD_PLIST"
+      launchctl load "$LAUNCHD_PLIST"
+      success "Restarted litellm-proxy LaunchAgent"
+      return 0
+    fi
+  fi
+
+  # Manual restart
+  if is_port_listening; then
+    cmd_stop
+    sleep 1
+  fi
+  cmd_start "$@"
+}
+
+# --- config -------------------------------------------------------------------
+
+cmd_config() {
+  case "${1:-}" in
+    --edit)
+      [ -f "$CONFIG_FILE" ] || die "Config not found: $CONFIG_FILE\nRun 'litellm setup' to create default config."
+      "${EDITOR:-vi}" "$CONFIG_FILE"
+      ;;
+    --validate)
+      [ -f "$CONFIG_FILE" ] || die "Config not found: $CONFIG_FILE"
+      if python3 -c "import yaml; yaml.safe_load(open('$CONFIG_FILE'))" 2>/dev/null; then
+        success "Config is valid YAML"
+      else
+        die "Config is not valid YAML: $CONFIG_FILE"
+      fi
+      ;;
+    "")
+      if [ -f "$CONFIG_FILE" ]; then
+        echo -e "${DIM}# $CONFIG_FILE${NC}"
+        cat "$CONFIG_FILE"
+      else
+        die "Config not found: $CONFIG_FILE\nRun 'litellm setup' to create default config."
+      fi
+      ;;
+    *)
+      die "Unknown config option: $1 (try --edit or --validate)"
+      ;;
+  esac
+}
+
+# --- models -------------------------------------------------------------------
+
+cmd_models() {
+  [ -f "$CONFIG_FILE" ] || die "Config not found: $CONFIG_FILE"
+  header "Configured Models"
+  awk '/model_name:/ {print "  " $2}' "$CONFIG_FILE"
+}
+
+# --- setup --------------------------------------------------------------------
+
+cmd_setup() {
+  header "LiteLLM Setup"
+
+  # Install litellm
+  if has litellm; then
+    local version
+    version=$(litellm --version 2>/dev/null | head -1 || echo "unknown")
+    success "litellm already installed ($version)"
+  else
+    if has uv; then
+      info "Installing litellm via uv..."
+      uv tool install 'litellm[proxy]'
+      success "litellm installed"
+    elif has pip3; then
+      info "Installing litellm via pip3..."
+      pip3 install --user 'litellm[proxy]'
+      success "litellm installed"
+    else
+      die "Neither uv nor pip3 found. Install uv first: brew install uv"
+    fi
+  fi
+
+  # Create config directory
+  if [ ! -d "$CONFIG_DIR" ]; then
+    mkdir -p "$CONFIG_DIR"
+    success "Created $CONFIG_DIR"
+  fi
+
+  # Create default config if missing
+  if [ ! -f "$CONFIG_FILE" ]; then
+    cat > "$CONFIG_FILE" << 'YAML'
+# LiteLLM Proxy Configuration
+# https://docs.litellm.ai/docs/proxy/configs
+#
+# API keys are read from environment variables via os.environ/.
+# Set them in ~/.config/litellm/env or export them in your shell.
+
+model_list:
+  # Anthropic
+  - model_name: claude-sonnet
+    litellm_params:
+      model: anthropic/claude-sonnet-4-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: claude-haiku
+    litellm_params:
+      model: anthropic/claude-haiku-4-5-20251001
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  # OpenAI
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+
+  # Ollama (local)
+  - model_name: llama3
+    litellm_params:
+      model: ollama/llama3
+      api_base: http://localhost:11434
+
+litellm_settings:
+  drop_params: true
+  set_verbose: false
+YAML
+    success "Created default config: $CONFIG_FILE"
+  else
+    success "Config already exists: $CONFIG_FILE"
+  fi
+
+  # Create env file template if missing
+  if [ ! -f "$ENV_FILE" ]; then
+    cat > "$ENV_FILE" << 'ENV'
+# LiteLLM environment variables
+# Uncomment and set your API keys:
+# ANTHROPIC_API_KEY=sk-ant-...
+# OPENAI_API_KEY=sk-...
+ENV
+    chmod 600 "$ENV_FILE"
+    success "Created env template: $ENV_FILE"
+    warn "Edit $ENV_FILE to add your API keys"
+  else
+    success "Env file already exists: $ENV_FILE"
+  fi
+
+  # Enable service
+  if [ "$IS_LINUX" = true ] || [ "$IS_WSL" = true ]; then
+    if has systemctl; then
+      local svc_file="$HOME/.config/systemd/user/litellm-proxy.service"
+      if [ -f "$svc_file" ]; then
+        systemctl --user daemon-reload
+        systemctl --user enable litellm-proxy
+        success "Enabled systemd user service"
+        info "Start with: systemctl --user start litellm-proxy"
+      else
+        warn "Service file not found: $svc_file"
+        info "Run 'chezmoi apply' to deploy the service file"
+      fi
+    fi
+  elif [ "$IS_MACOS" = true ]; then
+    if [ ! -f "$LAUNCHD_PLIST" ]; then
+      mkdir -p "$(dirname "$LAUNCHD_PLIST")"
+      cat > "$LAUNCHD_PLIST" << PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>${LAUNCHD_LABEL}</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>${HOME}/.local/bin/litellm</string>
+    <string>start</string>
+    <string>--service</string>
+  </array>
+  <key>RunAtLoad</key>
+  <false/>
+  <key>KeepAlive</key>
+  <dict>
+    <key>SuccessfulExit</key>
+    <false/>
+  </dict>
+  <key>StandardOutPath</key>
+  <string>${HOME}/.local/share/litellm/proxy.log</string>
+  <key>StandardErrorPath</key>
+  <string>${HOME}/.local/share/litellm/proxy.log</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>${HOME}/.local/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
+</dict>
+</plist>
+PLIST
+      mkdir -p "$HOME/.local/share/litellm"
+      success "Created LaunchAgent: $LAUNCHD_PLIST"
+      info "Load with: launchctl load $LAUNCHD_PLIST"
+    else
+      success "LaunchAgent already exists"
+    fi
+  fi
+
+  echo ""
+  success "Setup complete!"
+  info "Next steps:"
+  echo "  1. Edit API keys: \$EDITOR $ENV_FILE"
+  echo "  2. Edit models:   litellm config --edit"
+  echo "  3. Start proxy:   litellm start"
+}
+
+# --- help ---------------------------------------------------------------------
+
+show_help() {
+  cat << 'EOF'
+litellm - LiteLLM proxy wrapper
+
+USAGE
+  litellm              Show proxy status (same as litellm status)
+  litellm start        Start the proxy server (foreground)
+  litellm status       Show whether the proxy is running
+  litellm stop         Stop the proxy server
+  litellm restart      Restart the proxy server
+  litellm config       Show configuration file
+  litellm models       List configured models
+  litellm setup        Install litellm and create default config
+  litellm version      Show litellm version
+  litellm help         Show this help
+
+OPTIONS
+  litellm start --service    Suppress interactive messaging (for systemd/launchd)
+  litellm config --edit      Open config in $EDITOR
+  litellm config --validate  Check config YAML syntax
+
+CONFIGURATION
+  Config:  ~/.config/litellm/config.yaml
+  Env:     ~/.config/litellm/env (API keys)
+  Port:    $LITELLM_PORT (default 4000)
+  Host:    $LITELLM_HOST (default 0.0.0.0)
+
+SERVICE MANAGEMENT
+  Linux:   systemctl --user {start,stop,enable,disable} litellm-proxy
+  macOS:   launchctl {load,unload} ~/Library/LaunchAgents/com.user.litellm-proxy.plist
+
+EXAMPLES
+  litellm setup              # First-time install and configure
+  litellm start              # Start proxy in foreground
+  litellm models             # See configured models
+  litellm config --edit      # Edit model configuration
+  curl localhost:4000/v1/models  # Test the API endpoint
+EOF
+}
+
+# --- version ------------------------------------------------------------------
+
+show_version() {
+  if has litellm; then
+    litellm --version 2>/dev/null | head -1
+  else
+    echo "litellm not installed"
+  fi
+}
+
+# === Main =====================================================================
+
+main() {
+  case "${1:-}" in
+    ""|status)
+      cmd_status
+      ;;
+    start)
+      shift
+      cmd_start "$@"
+      ;;
+    stop)
+      cmd_stop
+      ;;
+    restart)
+      shift
+      cmd_restart "$@"
+      ;;
+    config)
+      shift
+      cmd_config "$@"
+      ;;
+    models)
+      cmd_models
+      ;;
+    setup)
+      cmd_setup
+      ;;
+    version|--version|-v)
+      show_version
+      ;;
+    help|--help|-h)
+      show_help
+      ;;
+    *)
+      die "Unknown command: $1 (try 'litellm help')"
+      ;;
+  esac
+}
+
+main "$@"

--- a/dot_local/bin/executable_sysmon
+++ b/dot_local/bin/executable_sysmon
@@ -572,6 +572,24 @@ cmd_status() {
     printf "  %-10s ${DIM}not listening${NC}\n" "SSH:"
   fi
 
+  if has litellm; then
+    local litellm_listening=false
+    if [ "$IS_MACOS" = true ]; then
+      if lsof -i :4000 -P -n 2>/dev/null | grep -q LISTEN; then
+        litellm_listening=true
+      fi
+    else
+      if ss -tln 2>/dev/null | grep -q ':4000 '; then
+        litellm_listening=true
+      fi
+    fi
+    if [ "$litellm_listening" = true ]; then
+      printf "  %-10s ${GREEN}listening${NC} (port 4000)\n" "LiteLLM:"
+    else
+      printf "  %-10s ${DIM}stopped${NC}\n" "LiteLLM:"
+    fi
+  fi
+
   # Backup
   if has sysbak; then
     header "Backup"

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -428,7 +428,7 @@ cmd_doctor() {
   done
 
   header "Development Tools"
-  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot)
+  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot litellm)
   for tool in "${tools_dev[@]}"; do
     check_tool "$tool"
   done
@@ -444,6 +444,7 @@ cmd_doctor() {
   check_path "$HOME/.oh-my-zsh" "oh-my-zsh"
   check_path "$HOME/.config/dev/config" "dev config"
   check_path "$HOME/.config/sysbak/config" "sysbak config"
+  check_path "$HOME/.config/litellm/config.yaml" "litellm config"
   check_path "$HOME/Projects" "Projects directory"
 
   # Linux-specific daemon health
@@ -510,6 +511,7 @@ get_version() {
     apt-get)   apt-get --version 2>/dev/null | head -1 | awk '{print $2}' ;;
     sysbak)    sysbak version 2>/dev/null ;;
     rsnapshot) rsnapshot --version 2>&1 | head -1 ;;
+    litellm)   litellm --version 2>/dev/null | head -1 ;;
     sensors)   sensors -v 2>/dev/null | awk '{print $3}' ;;
     sar)       sar -V 2>/dev/null | awk '{print $3}' ;;
     *)         "$tool" --version 2>/dev/null | head -1 ;;

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -156,6 +156,7 @@ if [ -z "$TMUX" ] && [ -z "$VSCODE_INJECTION" ] && [ -t 1 ]; then
   echo "  \033[36msysup doctor\033[0m      tool health check"
   echo "  \033[36msysmon\033[0m [status]   system health"
   echo "  \033[36msysbak\033[0m [status]   backup manager"
+  echo "  \033[36mlitellm\033[0m [start]    LLM proxy (port 4000)"
 
   if command -v tmux >/dev/null 2>&1; then
     _sessions=$(tmux list-sessions 2>/dev/null)
@@ -245,6 +246,17 @@ _sysbak_completion() {
   esac
 }
 compdef _sysbak_completion sysbak 2>/dev/null
+
+# litellm command completion
+_litellm_completion() {
+  local -a subcmds
+  subcmds=(start status stop restart config models setup version help)
+  _arguments '1:command:->cmd'
+  case $state in
+    cmd) _describe 'command' subcmds ;;
+  esac
+}
+compdef _litellm_completion litellm 2>/dev/null
 
 # source the PowerLevel10k config
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -608,6 +608,16 @@ else
   echo "Try: brew install uv"
 fi
 
+# Install LiteLLM proxy (requires uv)
+if command -v uv >/dev/null 2>&1; then
+  echo 'Installing LiteLLM proxy'
+  if ! command -v litellm >/dev/null 2>&1; then
+    uv tool install 'litellm[proxy]' || echo "Failed to install LiteLLM - continuing..."
+  else
+    echo 'LiteLLM already installed'
+  fi
+fi
+
 # Install Oh My Zsh (same everywhere)
 if [ ! -f ~/.oh-my-zsh/oh-my-zsh.sh ]; then
   (echo '💰  Installing oh-my-zsh' && yes | sh -c "$(curl -fsSL https://raw.github.com/ohmyzsh/ohmyzsh/master/tools/install.sh)")

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -70,6 +70,7 @@ run_lint() {
         "$REPO_DIR/dot_local/bin/executable_dev"
         "$REPO_DIR/dot_local/bin/executable_sysmon"
         "$REPO_DIR/dot_local/bin/executable_sysbak"
+        "$REPO_DIR/dot_local/bin/executable_litellm"
     )
 
     # Add run_once scripts (only pure shell, not .tmpl - Go templates confuse shellcheck)
@@ -120,6 +121,7 @@ run_syntax() {
         "$REPO_DIR/dot_local/bin/executable_dev"
         "$REPO_DIR/dot_local/bin/executable_sysmon"
         "$REPO_DIR/dot_local/bin/executable_sysbak"
+        "$REPO_DIR/dot_local/bin/executable_litellm"
     )
 
     for script in "${scripts[@]}"; do


### PR DESCRIPTION
## Summary

- Add `litellm` wrapper script for managing a LiteLLM proxy server that provides a unified OpenAI-compatible API endpoint for multiple LLM providers (Anthropic, OpenAI, Ollama)
- Follows the existing pattern of chezmoi-managed system utilities (`sysup`, `sysmon`, `sysbak`, `dev`)
- Includes systemd user service, default config, install integration, sysup/sysmon integration, zsh completion, tests, CI, and documentation

## New Files

| File | Purpose |
|------|---------|
| `dot_local/bin/executable_litellm` | Wrapper script: `start`, `stop`, `status`, `restart`, `config`, `models`, `setup`, `help`, `version` |
| `dot_config/litellm/create_config.yaml` | Default model config (Anthropic, OpenAI, Ollama) — only created if missing |
| `dot_config/systemd/user/litellm-proxy.service` | systemd user service with EnvironmentFile and restart-on-failure |
| `docs/litellm.md` | Usage documentation |

## Modified Files

| File | Change |
|------|--------|
| `run_once_install-packages.sh.tmpl` | Install `litellm[proxy]` via `uv tool install` |
| `dot_local/bin/executable_sysup` | Doctor: litellm binary + config checks |
| `dot_local/bin/executable_sysmon` | Services: LiteLLM port 4000 listening status |
| `dot_zshrc` | Welcome message line + tab completion |
| `tests/test.sh` | Lint + syntax checks for litellm script |
| `.github/workflows/test.yml` | Shellcheck + syntax steps (Ubuntu + macOS) |
| `CLAUDE.md` | Key Files + Documentation references |

## Test plan

- [x] `shellcheck -x -s bash dot_local/bin/executable_litellm` — passes
- [x] `bash -n dot_local/bin/executable_litellm` — syntax OK
- [x] `./tests/test.sh quick` — all 12 checks pass
- [x] `chezmoi apply --dry-run` — deploys cleanly
- [x] `litellm help` — shows usage
- [x] `litellm status` — shows stopped state
- [x] CI passes on Ubuntu + macOS

Closes #21