### PR TITLE
feat: add commonly-used base packages to install script

### DIFF
--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -573,13 +573,13 @@ cmd_doctor() {
   done
 
   header "Development Tools"
-  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot)
+  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot kubectl cmake git-lfs)
   for tool in "${tools_dev[@]}"; do
     check_tool "$tool"
   done
 
   header "Modern CLI Replacements"
-  local tools_cli=(eza bat fd rg delta btop zoxide jq sensors sar)
+  local tools_cli=(eza bat fd rg delta btop zoxide jq sensors sar yq pandoc ffmpeg yt-dlp)
   for tool in "${tools_cli[@]}"; do
     check_tool "$tool"
   done
@@ -657,6 +657,10 @@ get_version() {
     rsnapshot) rsnapshot --version 2>&1 | head -1 ;;
     sensors)   sensors -v 2>/dev/null | awk '{print $3}' ;;
     sar)       sar -V 2>/dev/null | awk '{print $3}' ;;
+    kubectl)   kubectl version --client 2>/dev/null | head -1 | awk '{print $3}' ;;
+    ffmpeg)    ffmpeg -version 2>/dev/null | head -1 | awk '{print $3}' ;;
+    git-lfs)   git-lfs version 2>/dev/null | awk '{print $1}' ;;
+    yq)        yq --version 2>/dev/null | awk '{print $NF}' ;;
     *)         "$tool" --version 2>/dev/null | head -1 ;;
   esac
 }

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -21,7 +21,9 @@
      "sqlite"
      "gh"
      "just"
-     "shellcheck" -}}
+     "shellcheck"
+     "kubectl"
+     "cmake" -}}
 
 {{ $modernCli := list
      "bat"
@@ -35,7 +37,13 @@
      "duf"
      "hyperfine"
      "procs"
-     "dust" -}}
+     "dust"
+     "git-lfs"
+     "pandoc"
+     "ffmpeg"
+     "yt-dlp"
+     "p7zip"
+     "yq" -}}
 
 {{ $macosSpecific := list 
      "python" 
@@ -68,9 +76,9 @@ is_wsl() {
 {{ if eq .osid "linux-debian" "linux-raspbian" "linux-pop" "linux-ubuntu" -}}
 echo '🐧 Installing Linux packages'
 
-{{ $linuxSpecific := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" -}}
-{{ $linuxWithDocker := list "python3" "python3-pip" "fontconfig" "docker.io" "openssh-client" "docker-compose-plugin" "gpg" "lm-sensors" "sysstat" -}}
-{{ $linuxWithoutDocker := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" -}}
+{{ $linuxSpecific := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" "mosquitto" "mosquitto-clients" "libasound2-dev" -}}
+{{ $linuxWithDocker := list "python3" "python3-pip" "fontconfig" "docker.io" "openssh-client" "docker-compose-plugin" "gpg" "lm-sensors" "sysstat" "mosquitto" "mosquitto-clients" "libasound2-dev" -}}
+{{ $linuxWithoutDocker := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" "mosquitto" "mosquitto-clients" "libasound2-dev" -}}
 {{ $sudo := "sudo " -}}
 {{ if eq .chezmoi.username "root" -}}
 {{   $sudo = "" -}}
@@ -250,9 +258,9 @@ echo '   Or: eval "$(~/.linuxbrew/bin/brew shellenv)"'
 install_brew_packages {{ $allBrewPackages | join " " }}
 {{ else -}}
 # Install modern CLI tools via apt for non-amd64 architectures
-install_apt_packages bat fd-find ncdu tmux duf hyperfine
-# Note: eza, delta, httpie, procs, dust may need alternative installation methods on ARM
-# Some of these may not be available on older Ubuntu/Debian versions
+install_apt_packages bat fd-find ncdu tmux duf hyperfine git-lfs pandoc ffmpeg p7zip-full
+# Note: eza, delta, httpie, procs, dust, yt-dlp, yq, kubectl, cmake may need alternative
+# installation methods on ARM. Some of these may not be available on older Ubuntu/Debian versions.
 {{ end -}}
 
 # Set up fnm and install Node.js (after Homebrew packages are installed)


### PR DESCRIPTION
## Summary

- Closes #35. Captures utilities installed manually across machines that the install script was missing.
- Brew channel: `kubectl`, `cmake` (to `brewPackages`); `git-lfs`, `pandoc`, `ffmpeg`, `yt-dlp`, `p7zip`, `yq` (to `modernCli`).
- Linux apt (all three list variants): `mosquitto`, `mosquitto-clients`, `libasound2-dev`.
- ARM apt fallback extended with the four packages that are reliably available (`git-lfs pandoc ffmpeg p7zip-full`).
- `sysup doctor` extended: `tools_dev` gains `kubectl`/`cmake`/`git-lfs`; `tools_cli` gains `yq`/`pandoc`/`ffmpeg`/`yt-dlp`; four new `get_version()` cases to trim verbose multi-field output.

## Test plan

- [x] `./tests/test.sh quick` passes (shellcheck + syntax).
- [x] `./tests/test-templates.sh` passes.
- [x] `chezmoi execute-template` rendered output contains all new packages in the correct install lists (apt + brew).
- [x] `sysup doctor` on pop-mini reports clean version strings for all new entries:
      `kubectl v1.35.3`, `cmake 3.22.1`, `git-lfs/3.7.1`, `yq v4.48.1`, `pandoc 3.9.0.2`, `ffmpeg 4.4.2-0ubuntu0.22.04.1`, `yt-dlp 2026.03.17`.
- [ ] Reviewer: CI green on Ubuntu + macOS runners.
- [ ] Post-merge: `chezmoi apply` on machines with pending updates picks up new `sysup doctor` entries (no package installs re-triggered since `run_once_install-packages.sh` state hash unchanged — rename or force-run needed to re-install on already-applied boxes).

## Scope notes

- `mosquitto` installs the broker as a systemd-enabled daemon on Linux. If that's undesired on any machine, disable with `sudo systemctl disable --now mosquitto`. Mentioned in #35.
- `kubectl` via brew avoids the need for a Kubernetes apt repo bootstrap; keeps the install path uniform across macOS and amd64 Linux.
- `libasound2-dev` is Linux-only (macOS has Core Audio).