### PR TITLE
feat(nix): Nix + devenv bootstrap (Linux-first, opt-in on macOS)

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -6,3 +6,4 @@
 
 [data]
     osid = {{ $osID | quote }}
+    install_nix = {{ if eq .chezmoi.os "linux" }}true{{ else }}false{{ end }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,7 @@ Detailed usage guides are in `docs/`:
 - [`docs/sysup.md`](docs/sysup.md) — System update utility reference
 - [`docs/sysmon.md`](docs/sysmon.md) — System health monitor reference
 - [`docs/sysbak.md`](docs/sysbak.md) — Backup manager reference
+- [`docs/devenv.md`](docs/devenv.md) — Nix + devenv per-project environments
 - [`docs/dotfiles-agent.md`](docs/dotfiles-agent.md) — Dotfiles agent setup and usage
 
 ## When Making Changes

--- a/docs/devenv.md
+++ b/docs/devenv.md
@@ -1,0 +1,48 @@
+# devenv
+
+Per-project reproducible development environments on top of Nix. Bootstrapped
+by `run_once_after_install-nix.sh.tmpl` on Linux when `install_nix=true` (the
+default); opt-in on macOS by flipping the flag in `~/.config/chezmoi/chezmoi.toml`.
+
+## Bootstrap
+
+1. `chezmoi apply` — installs Nix via the Determinate Systems installer and
+   `nix profile install nixpkgs#devenv`. Idempotent; safe to re-run.
+2. Open a new shell. The `nix` and `direnv` hooks are wired up in `dot_zshrc`.
+3. Verify: `sysup doctor` reports `nix`, `devenv`, `direnv` with versions.
+
+## Usage
+
+```bash
+cd my-project
+devenv init                    # scaffolds devenv.nix + devenv.yaml + .envrc
+direnv allow                   # one-time per project — lets direnv auto-activate
+```
+
+Subsequent `cd` into the project auto-loads the environment via direnv. Edit
+`devenv.nix` to add packages, services, scripts, processes. See the
+[devenv documentation](https://devenv.sh/) for the full schema.
+
+## Why this channel (not apt/brew)
+
+- Reproducibility: `devenv.lock` pins the exact Nix store paths, so every
+  machine that applies the same flake gets byte-identical tooling.
+- Isolation: project-scoped tools don't leak into `$PATH` globally.
+- Composition: mix language toolchains, databases, and services per-project
+  without cluttering the host.
+
+## Gotchas
+
+- First `devenv shell` after cloning a project can take minutes while Nix
+  realizes the closure. Subsequent activations are fast (store hit).
+- If the DetSys installer doesn't automatically configure your shell,
+  `dot_zshrc` sources `/nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh`
+  as a fallback.
+- `direnv allow` is per-directory trust. Re-run after cloning a new repo.
+
+## Related
+
+- [Upstream devenv docs](https://devenv.sh/)
+- [Determinate Nix Installer](https://install.determinate.systems/)
+- [thompsonson/dev#9](https://github.com/thompsonson/dev/issues/9) — devenv feature survey
+- [thompsonson/dev#10](https://github.com/thompsonson/dev/issues/10) — `dev` session integration plan

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -567,13 +567,13 @@ cmd_doctor() {
   echo "  User:     $(whoami)"
 
   header "Package Managers"
-  local tools_pm=(brew apt-get chezmoi fnm node npm uv pipx)
+  local tools_pm=(brew apt-get chezmoi fnm node npm uv pipx nix)
   for tool in "${tools_pm[@]}"; do
     check_tool "$tool"
   done
 
   header "Development Tools"
-  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot kubectl cmake git-lfs)
+  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot kubectl cmake git-lfs devenv direnv)
   for tool in "${tools_dev[@]}"; do
     check_tool "$tool"
   done
@@ -661,6 +661,9 @@ get_version() {
     ffmpeg)    ffmpeg -version 2>/dev/null | head -1 | awk '{print $3}' ;;
     git-lfs)   git-lfs version 2>/dev/null | awk '{print $1}' ;;
     yq)        yq --version 2>/dev/null | awk '{print $NF}' ;;
+    nix)       nix --version 2>/dev/null | awk '{print $NF}' ;;
+    devenv)    devenv version 2>/dev/null | awk '{print $NF}' ;;
+    direnv)    direnv --version 2>/dev/null ;;
     *)         "$tool" --version 2>/dev/null | head -1 ;;
   esac
 }

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -56,6 +56,18 @@ if command -v zoxide >/dev/null 2>&1; then
   eval "$(zoxide init zsh)"
 fi
 
+# Nix — source the daemon profile (multi-user) or single-user fallback
+if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+elif [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi
+
+# direnv — devenv relies on this for per-project auto-activation
+if command -v direnv >/dev/null 2>&1; then
+  eval "$(direnv hook zsh)"
+fi
+
 # Create missing completion directories to prevent errors (all platforms)
 mkdir -p ~/.antigen/bundles/robbyrussell/oh-my-zsh/cache/completions 2>/dev/null
 

--- a/run_once_after_install-nix.sh.tmpl
+++ b/run_once_after_install-nix.sh.tmpl
@@ -1,0 +1,50 @@
+#!/bin/bash
+# Nix + devenv bootstrap. Gated on install_nix data flag (default false if unset).
+{{- $installNix := false -}}
+{{- if hasKey . "install_nix" -}}{{- $installNix = .install_nix -}}{{- end }}
+{{ if not $installNix -}}
+exit 0
+{{ end -}}
+
+set -euo pipefail
+
+echo '❄️  Nix + devenv bootstrap'
+
+# Install Nix via Determinate Systems installer (handles systemd-resolved,
+# enables flakes by default, clean uninstall path).
+if ! command -v nix >/dev/null 2>&1 \
+   && ! [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  echo '  Installing Nix (Determinate Systems installer)'
+  curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix \
+    | sh -s -- install --no-confirm
+else
+  echo '  Nix already installed — skipping'
+fi
+
+# Source nix env for the current session so subsequent steps can call nix.
+if [ -f /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh ]; then
+  # shellcheck source=/dev/null
+  . /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+elif [ -f "$HOME/.nix-profile/etc/profile.d/nix.sh" ]; then
+  # shellcheck source=/dev/null
+  . "$HOME/.nix-profile/etc/profile.d/nix.sh"
+fi
+
+# Ensure user-level flakes config. Belt-and-suspenders: DetSys enables this in
+# /etc/nix/nix.conf, but keep a user-level entry so the flag is explicit even
+# if someone swaps installers later.
+mkdir -p "$HOME/.config/nix"
+if ! grep -q 'experimental-features' "$HOME/.config/nix/nix.conf" 2>/dev/null; then
+  echo 'experimental-features = nix-command flakes' >> "$HOME/.config/nix/nix.conf"
+  echo '  Enabled flakes in ~/.config/nix/nix.conf'
+fi
+
+# Install devenv via nix profile.
+if command -v nix >/dev/null 2>&1 && ! command -v devenv >/dev/null 2>&1; then
+  echo '  Installing devenv'
+  nix profile install nixpkgs#devenv
+else
+  echo '  devenv already installed — skipping'
+fi
+
+echo '✅ Nix bootstrap complete. Open a new shell to pick up nix + direnv hooks.'


### PR DESCRIPTION
## Summary

- Closes #26 (Group A). Foundation for the Nix-based feature groups that follow.
- New `install_nix` data flag in `.chezmoi.toml.tmpl` — default `true` on Linux, `false` on macOS.
- New `run_once_after_install-nix.sh.tmpl` that installs Nix via the Determinate Systems installer (flakes on by default), sources the nix-daemon profile, ensures user-level flakes config, and `nix profile install nixpkgs#devenv`.
- `dot_zshrc` gains two guarded blocks: nix-daemon profile source (with single-user fallback) and `direnv hook zsh`.
- `sysup doctor` gains `nix` (tools_pm) and `devenv`/`direnv` (tools_dev), plus `get_version()` cases.
- New `docs/devenv.md` with the bootstrap + per-project usage recipe.

## Test plan

- [x] `./tests/test.sh quick` passes.
- [x] `./tests/test-templates.sh` passes — `run_once_after_install-nix.sh.tmpl` renders and `bash -n`-checks cleanly both with `install_nix=true` (full script) and missing key (early `exit 0`).
- [x] Template uses `hasKey` guard so rendering succeeds on machines whose `chezmoi.toml` was generated before this PR — no manual `chezmoi init` step required to avoid errors; it just no-ops.
- [x] Post-merge on pop-mini (reviewer): run `chezmoi init --source=\$PWD` (refreshes `~/.config/chezmoi/chezmoi.toml` with the new flag) then `chezmoi apply`. First apply triggers the DetSys installer, which invokes sudo. Expect:
  - `/nix/store` populated, `nix-daemon.service` running (systemd).
  - `which nix devenv direnv` in a new shell all resolve.
  - `sysup doctor` reports version lines for all three.
  - `devenv init && direnv allow` in a throwaway project produces a working `devenv shell`.

## Non-goals / explicit scope

- **Not** wiring devenv into the `dev` session manager. That's tracked upstream in thompsonson/dev#10.
- **Not** installing `cloud-hypervisor` / `virtiofsd` — those land in Group B (#27) together with #34's consolidated `setup-host-linux.sh`.
- **Not** adding a `sysup upgrade` handler for `nix profile upgrade` — that's #32 (Group G), filed as a follow-up once at least two toolchains are in.

## Idempotency notes

- Re-applying: DetSys installer detects existing `/nix` and skips. `nix profile install` is a no-op if devenv is already in the profile.
- Flag flip false→true: script re-runs (content hash changes) and installs.
- Flag flip true→false: script re-runs but exits 0 early. Nix is **not uninstalled** — removal is out of scope for chezmoi apply and belongs to the user (DetSys installer provides `/nix/nix-installer uninstall`).

## Related

- Blocks #27 (Group B: microVM host prep) and #33 (Group H: sysbak `/nix/store` excludes).
- Loosely coupled to #32 (Group G: sysup upgrade coverage).