### PR TITLE
feat(sysbak): auto-exclude /nix/store from backups when Nix is present

### DIFF
--- a/dot_config/sysbak/create_config
+++ b/dot_config/sysbak/create_config
@@ -10,6 +10,16 @@
 #     ~/.local/share/chezmoi
 # )
 #
+# Exclude patterns — defaults cover node_modules, __pycache__, caches, .git/objects.
+# When /nix/store exists, the script also auto-appends the Nix store + caches
+# (they're reproducible from flake.lock). Override here only if you need to
+# customise; setting this replaces the defaults entirely, so include Nix yourself:
+# exclude_patterns=(
+#     "node_modules/" ".cache/" "__pycache__/" ".venv/" "*.pyc" ".git/objects/"
+#     # Nix — reproducible from flake.lock, never back up the store
+#     "/nix/store" "/nix/var" "~/.cache/nix" "~/.local/state/nix"
+# )
+#
 # Staleness thresholds (hours)
 # stale_warn_hours=25
 # stale_crit_hours=48

--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -99,6 +99,11 @@ if [[ -n "${exclude_patterns+x}" ]]; then
   EXCLUDE_PATTERNS=("${exclude_patterns[@]}")
 else
   EXCLUDE_PATTERNS=("node_modules/" ".cache/" "__pycache__/" ".venv/" "*.pyc" ".git/objects/")
+  # Nix store is fully reproducible from flake.lock — never back it up.
+  # Auto-append when Nix is present so default backups don't balloon.
+  if [[ -d /nix/store ]]; then
+    EXCLUDE_PATTERNS+=("/nix/store" "/nix/var" "$HOME/.cache/nix" "$HOME/.local/state/nix")
+  fi
 fi
 
 # Global flags
@@ -880,6 +885,27 @@ cmd_doctor() {
       printf "  ${GREEN}✓${NC} %-18s %s\n" "cron:" "/etc/cron.d/sysbak exists"
     else
       printf "  ${YELLOW}⚠${NC} %-18s %s\n" "cron:" "/etc/cron.d/sysbak missing"
+    fi
+  fi
+
+  # Exclude patterns
+  if [[ "$quiet" = false ]]; then
+    header "Exclude patterns"
+    printf "  %-20s %d patterns\n" "  Total:" "${#EXCLUDE_PATTERNS[@]}"
+    if [[ -d /nix/store ]]; then
+      local nix_excluded=false
+      for pat in "${EXCLUDE_PATTERNS[@]}"; do
+        if [[ "$pat" = "/nix/store" ]] || [[ "$pat" = "/nix/store/" ]]; then
+          nix_excluded=true
+          break
+        fi
+      done
+      if [[ "$nix_excluded" = true ]]; then
+        printf "  ${GREEN}✓${NC} %-18s %s\n" "Nix store:" "excluded"
+      else
+        printf "  ${YELLOW}⚠${NC} %-18s %s\n" "Nix store:" "/nix/store is present but NOT excluded — backups will balloon"
+        issues=$((issues + 1))
+      fi
     fi
   fi
 


### PR DESCRIPTION
## Summary

- Closes #33 (Group H). Protective pre-flight for Nix-equipped machines — stops the first post-Nix `sysbak run` from swallowing tens of GiB of reproducible store into the rsnapshot rotation.
- Runtime detection (check `[ -d /nix/store ]`) rather than chezmoi template flag, so the exclusion works regardless of `install_nix` data state and catches machines where Nix was bootstrapped outside the dotfiles path.
- User overrides unchanged: setting `exclude_patterns` in the config still replaces defaults entirely. Recommended pattern now documented in `create_config`.
- New `sysbak doctor` "Exclude patterns" section warns if Nix is present but `/nix/store` isn't excluded — catches config drift.

## Paths excluded when `/nix/store` exists

- `/nix/store` — the reproducible store (tens of GiB)
- `/nix/var` — daemon state, GC roots; rebuild on fresh install
- `~/.cache/nix` — eval cache; worthless backup target
- `~/.local/state/nix` — profile history; rebuildable

## Test plan

- [x] `./tests/test.sh quick` passes (shellcheck + syntax).
- [x] Sourcing the script manually on pop-mini populates `EXCLUDE_PATTERNS` with the Nix paths in addition to the existing defaults.
- [x] Templates still validate (`./tests/test-templates.sh`).
- [ ] Reviewer: on a machine without `/nix/store`, `EXCLUDE_PATTERNS` unchanged.
- [ ] Reviewer: on a machine with `/nix/store` and user-set `exclude_patterns` that omits Nix, `sysbak doctor` warns (assuming #42 is resolved — see caveat below).
- [ ] Reviewer: first `sysbak run` after merge on pop-mini completes materially faster than a baseline that'd include `/nix/store`.

## Known caveat

The new doctor section is currently unreachable on pop-mini due to a pre-existing SIGPIPE in the rsync version check — filed as **#42**. Once #42 lands, the "Exclude patterns" section becomes visible. The primary protection (the default excludes) works regardless — it runs at script-source time, before `doctor` is invoked.

## Explicit non-goals

- No changes to restore semantics. Excluded paths stay excluded on restore; Nix will rebuild the store on `nix build` post-restore.
- No changes to cargo/rustup/gradle excludes (#33 mentioned these as possible additions). Those belong with #28 (Rust) / #31 (Android) respectively — no value adding them today without the toolchains.
- No changes to `sysbak git-bundle` or any other subcommand.

## Related

- Unblocked by #26 / PR #40 (Group A: Nix bootstrap).
- Loosely coupled to #42 (sysbak doctor SIGPIPE) — fixing that exposes the new doctor warning on machines where rsync triggers the pre-existing bug.