### PR TITLE
fix(nix): install devenv direnvrc so `use devenv` in .envrc works

### DIFF
--- a/docs/devenv.md
+++ b/docs/devenv.md
@@ -15,13 +15,22 @@ default); opt-in on macOS by flipping the flag in `~/.config/chezmoi/chezmoi.tom
 
 ```bash
 cd my-project
-devenv init                    # scaffolds devenv.nix + devenv.yaml + .envrc
+devenv init                    # scaffolds devenv.nix + devenv.yaml + .gitignore
+echo 'use devenv' > .envrc     # devenv 2.x does not create this automatically
 direnv allow                   # one-time per project — lets direnv auto-activate
 ```
 
 Subsequent `cd` into the project auto-loads the environment via direnv. Edit
 `devenv.nix` to add packages, services, scripts, processes. See the
 [devenv documentation](https://devenv.sh/) for the full schema.
+
+### About `use devenv`
+
+`use devenv` is a helper function defined in `~/.config/direnv/direnvrc`
+(installed by the bootstrap script via `devenv direnvrc`). Direnv's stdlib
+does not ship this function, so without the direnvrc file, `.envrc` files
+fail with `use_devenv: command not found` — a single red line that easily
+scrolls off. If you see that, re-run `chezmoi apply` and open a new shell.
 
 ## Why this channel (not apt/brew)
 

--- a/run_once_after_install-nix.sh.tmpl
+++ b/run_once_after_install-nix.sh.tmpl
@@ -50,12 +50,13 @@ fi
 # Install devenv's direnv integration so `use devenv` in .envrc works.
 # direnv's stdlib doesn't ship `use_devenv`; devenv provides it via the
 # `devenv direnvrc` subcommand. Install if missing; refresh if ours
-# (marker: DEVENV_DIRENVRC_VERSION — a public contract in devenv's source);
-# leave alone if a user-custom direnvrc exists.
+# (detected by the anchored `export DEVENV_DIRENVRC_VERSION=` line — a
+# public contract at the top of `devenv direnvrc` output); leave alone
+# if a user-custom direnvrc exists.
 if command -v devenv >/dev/null 2>&1; then
   direnvrc_path="$HOME/.config/direnv/direnvrc"
   mkdir -p "$HOME/.config/direnv"
-  if [ ! -f "$direnvrc_path" ] || grep -q DEVENV_DIRENVRC_VERSION "$direnvrc_path"; then
+  if [ ! -f "$direnvrc_path" ] || grep -qE '^[[:space:]]*export DEVENV_DIRENVRC_VERSION=' "$direnvrc_path"; then
     devenv direnvrc > "$direnvrc_path"
     echo "  Installed devenv direnvrc -> $direnvrc_path"
   else

--- a/run_once_after_install-nix.sh.tmpl
+++ b/run_once_after_install-nix.sh.tmpl
@@ -47,4 +47,20 @@ else
   echo '  devenv already installed — skipping'
 fi
 
+# Install devenv's direnv integration so `use devenv` in .envrc works.
+# direnv's stdlib doesn't ship `use_devenv`; devenv provides it via the
+# `devenv direnvrc` subcommand. Install if missing; refresh if ours
+# (marker: DEVENV_DIRENVRC_VERSION — a public contract in devenv's source);
+# leave alone if a user-custom direnvrc exists.
+if command -v devenv >/dev/null 2>&1; then
+  direnvrc_path="$HOME/.config/direnv/direnvrc"
+  mkdir -p "$HOME/.config/direnv"
+  if [ ! -f "$direnvrc_path" ] || grep -q DEVENV_DIRENVRC_VERSION "$direnvrc_path"; then
+    devenv direnvrc > "$direnvrc_path"
+    echo "  Installed devenv direnvrc -> $direnvrc_path"
+  else
+    echo "  existing custom direnvrc at $direnvrc_path -> skipping"
+  fi
+fi
+
 echo '✅ Nix bootstrap complete. Open a new shell to pick up nix + direnv hooks.'


### PR DESCRIPTION
## Summary

- Closes #45. Final piece of Group A (#26 / #40) — without the direnvrc file, devenv projects with `use devenv` in `.envrc` fail silently (`use_devenv: command not found` scrolls off before the user can read it).
- Adds a block at the end of `run_once_after_install-nix.sh.tmpl` that installs `~/.config/direnv/direnvrc` via `devenv direnvrc`.
- Fixes two lies in `docs/devenv.md`: `devenv init` doesn't create `.envrc` in devenv 2.x, and the `use devenv` machinery needed a brief explanation.

## Idempotency

Per the review on #45, fixed the flipped-negation bug in the original proposal. The logic now is:

| State | Action |
|---|---|
| File missing | install |
| File exists, `DEVENV_DIRENVRC_VERSION` marker present | refresh (overwrite) — picks up devenv version updates |
| File exists, no marker (user-custom) | skip, log it |

The marker is a public contract: `export DEVENV_DIRENVRC_VERSION=2` appears on line 32 of `devenv direnvrc` output (verified against devenv 1.10 on pop-mini).

## Test plan

- [x] `./tests/test.sh quick` passes.
- [x] `./tests/test-templates.sh` passes (template renders and `bash -n`-checks).
- [x] Marker verified present in `devenv direnvrc` output on pop-mini.
- [ ] Reviewer: fresh apply on a machine without `~/.config/direnv/direnvrc` installs the file; subsequent apply refreshes (overwrites) since the marker is there.
- [ ] Reviewer: on a machine with a user-custom direnvrc (no marker), script logs "skipping" and leaves the file alone.
- [ ] Reviewer: `thompsonson/dev#14` L3a (`use devenv` in `.envrc`) passes end-to-end after apply + shell reload.

## Applying on pop-mini post-merge

```
chezmoi apply             # re-runs run_once_after_install-nix.sh (content hash changed)
ls ~/.config/direnv/direnvrc   # should exist with DEVENV_DIRENVRC_VERSION
exec zsh
cd /tmp/devenv-smoke && echo 'use devenv' > .envrc && direnv allow    # should activate cleanly
```

## Scope notes

- No changes to the `install_nix` flag semantics or gating. The block is nested under the existing `install_nix` branch via the whole script.
- No changes to how devenv itself is installed. Just wires up the direnv integration that the existing install was missing.
- Doesn't attempt to merge with user-custom direnvrc content — if someone has their own file, they're responsible for including `use_devenv` (or sourcing `/nix/store/.../direnvrc`) themselves.

## Related

- #40 — Group A: Nix + devenv bootstrap (this closes the last gap).
- thompsonson/dev#14 — end-to-end validation test (will re-run after merge).
- thompsonson/dev#10 — consumer "easiest path" bullet becomes true after this.

---

## Update: marker match hardened (addresses #47)

Also closes #47. The original marker check () matched the variable name anywhere — a user-custom direnvrc that merely commented on the variable would be misidentified as ours and silently overwritten.

Fixed in 28a2e26 by anchoring the match to an actual export line. Reviewer on the PR proposed `^export DEVENV_DIRENVRC_VERSION=`, but the real output indents that line inside a function (verified on devenv 1.10: `··export·DEVENV_DIRENVRC_VERSION=2`). Final form:

```
grep -qE '^[[:space:]]*export DEVENV_DIRENVRC_VERSION='
```

Which honours the reviewer's anchoring intent while matching the actual format.

Verified:
- `devenv direnvrc` output → matches
- Comment mentioning the variable by name → rejected

Closes #47.