### PR TITLE
fix(doctor): repair two version-capture bugs in sysbak + sysup

### DIFF
--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -863,8 +863,10 @@ cmd_doctor() {
     if has "$dep"; then
       local ver
       case "$dep" in
-        rsnapshot) ver=$(rsnapshot --version 2>&1 | head -1) ;;
-        rsync)     ver=$(rsync --version 2>/dev/null | head -1 | awk '{print $3}') ;;
+        # awk 'NR==1 ... exit' reads and exits after line 1 — avoids SIGPIPE
+        # that `cmd | head -1` triggers on long-output commands under pipefail.
+        rsnapshot) ver=$(rsnapshot --version 2>&1 | awk 'NR==1 {print; exit}') ;;
+        rsync)     ver=$(rsync --version 2>/dev/null | awk 'NR==1 {print $3; exit}') ;;
       esac
       [[ "$quiet" = false ]] && printf "  ${GREEN}✓${NC} %-18s %s\n" "$dep:" "$ver"
     else

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -662,7 +662,7 @@ get_version() {
     git-lfs)   git-lfs version 2>/dev/null | awk '{print $1}' ;;
     yq)        yq --version 2>/dev/null | awk '{print $NF}' ;;
     nix)       nix --version 2>/dev/null | awk '{print $NF}' ;;
-    devenv)    devenv version 2>/dev/null | awk '{print $NF}' ;;
+    devenv)    devenv version 2>/dev/null | awk '{print $2}' ;;
     direnv)    direnv --version 2>/dev/null ;;
     *)         "$tool" --version 2>/dev/null | head -1 ;;
   esac


### PR DESCRIPTION
## Summary

- Closes **#41** (devenv version shown as `(x86_64-linux)` instead of `2.0.6` in `sysup doctor`).
- Closes **#42** (sysbak doctor SIGPIPE exits after Dependencies; truncates everything downstream including the #43 Exclude patterns section).
- Both are one-line `get_version()` fixes found during Group A end-to-end validation.

## #42 fix — sysbak doctor SIGPIPE

**Root cause:** under `set -euo pipefail`, `cmd | head -1` can trigger SIGPIPE (141) when `cmd` produces more output than `head` reads. pipefail propagates the 141 out of `ver=\$(...)` and kills the script. Hit by the rsync version capture on pop-mini; latent in rsnapshot too.

**Fix:** `awk 'NR==1 {print; exit}'` — reads line 1, prints, exits cleanly before its upstream hits a closed pipe. Applied symmetrically to both dep cases.

**Before / after on pop-mini:**
```
BEFORE: [exits 141 after "rsnapshot:" line, nothing else shown]
AFTER:  Dependencies → Schedule → Exclude patterns → Snapshots → "All checks passed"
```

The "Exclude patterns" section from #43 is now visible and reports `✓ Nix store: excluded`.

## #41 fix — devenv version parse

**Root cause:** `devenv version` in devenv 2.x outputs `devenv 2.0.6 (x86_64-linux)` — one line, platform in the last field. My original `awk '{print \$NF}'` grabbed the platform tag.

**Fix:** `awk '{print \$2}'`. `sysup doctor` now shows `✓ devenv 2.0.6`.

## Test plan

- [x] `./tests/test.sh quick` passes (shellcheck + syntax).
- [x] `sysbak doctor` on pop-mini completes to "All checks passed" (exit 0).
- [x] `sysup doctor` on pop-mini shows `devenv 2.0.6` (with nix PATH sourced).
- [ ] Reviewer: CI green on Ubuntu + macOS.
- [ ] Reviewer: no regression on machines without rsync issues (rsnapshot-only boxes still show rsnapshot version).

## Scope notes

- The rsnapshot version-capture change is defensive — on pop-mini rsnapshot emits a single line so no SIGPIPE, but using the same awk shape on both is cheaper than conditional handling and matches how the rest of `get_version()` is moving.
- No other doctor cases were touched. Known cosmetic glitches noted in #41's "Scope notes" (`btop` multi-line version, `eza` echoing its own name, `sar` leaking "Godard") remain open; track separately if wanted.