### PR TITLE
fix(sysbak): preserve config customizations when re-running setup

### DIFF
--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -686,23 +686,45 @@ cmd_setup() {
   [[ "$new_mount" == /* ]]     || die "Mount point must be an absolute path (got: $new_mount)"
   [[ "$new_label" =~ ^[a-zA-Z0-9_-]+$ ]] || die "Label must be alphanumeric (got: $new_label)"
 
-  # Write config
-  cat > "$CONFIG_FILE" <<EOF
-# sysbak configuration
-device=$new_device
-mount_point=$new_mount
-label=$new_label
-
-# Backup directories
-backup_dirs=(
-    ~/Projects
-    ~/.local/share/chezmoi
-)
-
-# Staleness thresholds (hours)
-stale_warn_hours=25
-stale_crit_hours=48
-EOF
+  # Write config — preserve existing backup_dirs / exclude_patterns / staleness
+  # thresholds when they were set in the loaded config. Without this, re-running
+  # `sysbak setup` would silently reset customizations to defaults.
+  {
+    echo "# sysbak configuration"
+    echo "device=$new_device"
+    echo "mount_point=$new_mount"
+    echo "label=$new_label"
+    echo
+    echo "# Backup directories"
+    echo "backup_dirs=("
+    if [[ -n "${backup_dirs+x}" ]]; then
+      for d in "${BACKUP_DIRS[@]}"; do
+        # Quote $HOME and escape ~ so the replacement isn't re-tilde-expanded.
+        printf '    %s\n' "${d/#"$HOME"/\~}"
+      done
+    else
+      # Literal ~ is intentional: it's emitted into the config file and
+      # tilde-expanded when that file is sourced on the next sysbak run.
+      # shellcheck disable=SC2088
+      printf '    %s\n' '~/Projects' '~/.local/share/chezmoi'
+    fi
+    echo ")"
+    # Only emit exclude_patterns if user customized it — otherwise leave unset so
+    # defaults (including auto-Nix detection at load time) keep applying.
+    if [[ -n "${exclude_patterns+x}" ]]; then
+      echo
+      echo "# Exclude patterns"
+      echo "exclude_patterns=("
+      for p in "${EXCLUDE_PATTERNS[@]}"; do
+        printf '    "%s"\n' "$p"
+      done
+      echo ")"
+    fi
+    echo
+    echo "# Staleness thresholds (hours)"
+    echo "stale_warn_hours=$STALE_WARN_HOURS"
+    echo "stale_crit_hours=$STALE_CRIT_HOURS"
+  } > "$CONFIG_FILE"
   success "  Config written to $CONFIG_FILE"
 
   # Step 5: Create mount point


### PR DESCRIPTION
## Summary
- `sysbak setup` was overwriting `~/.config/sysbak/config` with a hardcoded template, silently resetting `backup_dirs` and staleness thresholds to defaults on every re-run.
- The script's own error message at line 222 (`"No device configured. Run 'sysbak setup' or edit $CONFIG_FILE"`) treats the file as a user-edit target, but `cmd_setup` was treating it as scratch space — a quiet data-loss footgun in a backup tool.
- Setup now emits the in-memory `BACKUP_DIRS` / `STALE_*` values when the config was loaded, falling back to the original defaults only on first run. Paths under `$HOME` are written as `~` for portability across machines. `exclude_patterns` is only written back when the user explicitly customized it, so the auto-Nix-detection default keeps applying on machines that haven't been re-setup since #43.

## Why this matters
`sysbak setup` is the only documented way to regenerate `/etc/rsnapshot.conf` from `backup_dirs`. With the bug, the canonical "edit config + re-run setup" workflow lost the very edits it was meant to propagate. Found while trying to add `~/.claude/projects` to the backup list.

## Test plan
- [x] `./tests/test.sh quick` — shellcheck + bash -n clean
- [x] Manually verified config rendering for both cases:
  - existing config with custom `backup_dirs` (7 entries) → all 7 preserved, `$HOME` round-tripped to `~`
  - first-run (no config) → original two-entry default
- [x] Run `sysbak setup` end-to-end on popmini and verify `~/.config/sysbak/config` is unchanged after a re-run, and `/etc/rsnapshot.conf` correctly includes all entries