### PR TITLE
fix(sysbak): add one_fs to rsnapshot.conf default

### DIFF
--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -739,6 +739,7 @@ verbose	2
 loglevel	3
 logfile	/var/log/rsnapshot.log
 lockfile	/var/run/rsnapshot.pid
+one_fs	1
 $(printf '%b' "$exclude_args")
 EOF
 


### PR DESCRIPTION
## Summary
- Adds `one_fs 1` to the rsnapshot.conf heredoc written by `sysbak setup`. Tells rsnapshot/rsync not to cross filesystem boundaries when traversing backup paths — equivalent to rsync's `--one-file-system`.
- Without it, any mount point that appears under a `backup_dir` (sshfs, NFS, encfs, container overlayfs, bind mount) gets walked into — slow, huge, and on bad days fills the USB drive enough to break snapshot rotation.

## Why now
Hit on popmini while verifying #49: the previous `/etc/rsnapshot.conf` had `one_fs 1` hand-set, but `sysbak setup` regenerates the file from this heredoc wholesale each run, so the hand-edit got silently dropped. Making it a built-in default — the conservative choice for any backup tool, and what rsnapshot's own example config recommends — fixes this without teaching `cmd_setup` to preserve hand-edits to `/etc/rsnapshot.conf`.

No effect on machines without mount points under any `backup_dir` (the common case).

## Test plan
- [x] `./tests/test.sh quick` — lint + syntax clean
- [ ] On popmini: re-run `sysbak setup`, confirm `/etc/rsnapshot.conf` now contains `one_fs	1`, run a `sysbak run alpha --dry-run` and verify rsync invocation includes `--one-file-system`

## Related
Follow-up to #49.