### PR TITLE
docs: Claude session analysis and telemetry planning

### DIFF
--- a/docs/claude-session-analysis.md
+++ b/docs/claude-session-analysis.md
@@ -1,0 +1,177 @@
+# Claude Session Data — Storage, Retention & Style Analysis
+
+Analysis run on popmini, 2026-04-28.
+
+---
+
+## 1. What Claude stores on disk
+
+Session transcripts live at `~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`.
+Each JSONL file is a full bidirectional transcript: user prompts, assistant
+responses (including extended thinking), tool calls and results, file-history
+snapshots (pre-edit copies of every file Claude touched), permission events,
+PR links, and session metadata.
+
+**It is not metadata-only.** A typical day's sessions contain the complete
+text of every response Claude generated.
+
+### Inventory (popmini, 2026-04-28)
+
+```
+1871 session files across 20 project dirs
+522 MB total
+
+Age distribution (by mtime):
+   7 days:  1779 files
+  30 days:  1405 files
+  60 days:   899 files
+  90 days:    35 files
+ 180 days:     0 files
+
+Oldest file:  2026-01-13
+Newest file:  2026-04-27
+```
+
+Data goes back to 2026-01-13 (~104 days). Nothing older exists — likely a
+reinstall or cleanup around that date.
+
+### What `codeburn` shows vs what's on disk
+
+codeburn was showing ~1 month of data. The disk has ~3 months. The difference
+is a display-windowing issue in codeburn, not data loss.
+
+### Backup status before this session
+
+`~/.claude/projects/` was **not** included in `sysbak`. Fixed — see PRs #49 and #50.
+
+---
+
+## 2. Phrase frequency analysis
+
+### Setup
+
+```bash
+# Extract all assistant text+thinking blocks with date and model
+find ~/.claude/projects -name '*.jsonl' -print0 | xargs -0 cat | \
+  jq -r 'select(.type=="assistant") |
+    .timestamp[:10] as $d |
+    (.message.model // "unknown") as $m |
+    .message.content[]? |
+    (.text // .thinking // empty) |
+    select(. != "") |
+    [$d, $m, (gsub("\n"; " "))] | @tsv' \
+  > /tmp/assistant_text_model.tsv
+```
+
+Result: **16,161 text/thinking blocks** from 72 active days (Feb–Apr 2026).
+
+### "load bearing" and "push back" — totals by model
+
+| Model | Blocks | "load bearing" | per 1k | "push back" | per 1k |
+|---|---:|---:|---:|---:|---:|
+| **claude-opus-4-7** | 1,275 | 26 | **20.4** | 16 | **12.6** |
+| claude-opus-4-6 | 8,197 | 17 | 2.1 | 8 | 1.0 |
+| claude-haiku-4-5 | 5,922 | 3 | 0.5 | 0 | 0 |
+| claude-sonnet-4-5/4-6, opus-4-5 | <300 each | 0 | 0 | 0 | 0 |
+
+**Opus 4-7 uses "load bearing" ~10× more per block than 4-6, and "push back" ~13× more.**
+
+### "load bearing" and "push back" — per day (all active days)
+
+```
+date          load-bearing   push-back
+--------------------------------------
+2026-02-02               0           0
+2026-02-03               0           0
+...
+2026-03-25               3           0   ← first appearance of either phrase
+2026-03-26               0           0
+2026-03-27               2           0
+2026-03-28               0           0
+2026-03-29               0           0
+2026-03-30               0           0
+2026-03-31               1           0
+2026-04-01               0           0
+2026-04-02               0           0
+2026-04-03               1           0
+2026-04-04               0           0
+...
+2026-04-12               0           1
+2026-04-13               0           0
+2026-04-14               0           0
+2026-04-15               9           6   ← single-day peak
+2026-04-16               2           0
+2026-04-17               0           0
+2026-04-18               0           0
+2026-04-19               1           0
+2026-04-20               0           0
+2026-04-21               6           2   ← opus 4-7 takes over from here
+2026-04-22               2           0
+2026-04-23               1           1
+2026-04-24               5           2
+2026-04-25               1           0
+2026-04-26               7           3
+2026-04-27               1           5
+2026-04-28               1           1
+--------------------------------------
+TOTAL                   43          21
+```
+
+Neither phrase appears in Feb or most of March. "Load bearing" first shows up
+on 2026-03-25; "push back" not until 2026-04-12.
+
+The visible uptick from 2026-04-21 is mostly the model switch: opus 4-7 went
+into use around that date.
+
+---
+
+## 3. N-gram style analysis
+
+### Methodology
+
+Extract all bigrams and trigrams from assistant blocks, compute occurrence
+rate per 1000 blocks per model, rank by opus-4-7 / opus-4-6 ratio. Two passes:
+
+- **All n-grams** (including those appearing in only one model) — surfaces
+  topic differences, mostly project-specific terms.
+- **N-grams present in both models** — surfaces style/vocabulary differences
+  that are model-characteristic rather than project-characteristic.
+
+### Key finding: 4-6 narrates, 4-7 acts
+
+The phrases most over-represented in **4-6 vs 4-7** are all narration phrases:
+
+| Phrase | 4-6 rate/1k | 4-7 rate/1k | 4-6 / 4-7 ratio |
+|---|---:|---:|---:|
+| "now let me" | 93.3 | 9.4 | **10×** |
+| "now let" | 93.3 | 10.2 | 9× |
+| "let me update" | 16.1 | 3.1 | 5× |
+| "let me fix" | 16.8 | 3.9 | 4× |
+| "let me also" | 28.7 | 6.3 | 5× |
+| "let me check the" | 38.1 | 7.8 | 5× |
+| "to understand" | 26.5 | 3.1 | 8× |
+| "now have" | 33.1 | 7.1 | 5× |
+
+4-6 externalises its reasoning step-by-step ("Now let me check…", "Let me
+also look at…", "Now I have…"). 4-7 drops this narration and just acts —
+but compensates with evaluative commentary ("load bearing", "push back",
+"worth noting").
+
+### Limitation
+
+The n-gram comparison is confounded by project: 4-6 was used Feb–Apr 19
+mainly on chezmoi/dotfiles and atomicguard work; 4-7 was used Apr 21–28
+on additional projects (Next.js, Playwright CI, manta-deploy). Phrases unique
+to 4-7 are mostly project-specific tech terms, not style markers. Only phrases
+appearing in **both** models are clean signals for style comparison.
+
+---
+
+## 4. Privacy note
+
+Session JSONL files contain the full text of every prompt you sent and every
+response Claude generated, including file contents pasted as context and
+pre-edit file snapshots. Back up to trusted storage only.
+
+Files are not rotated by Claude Code — they accumulate indefinitely.
+522 MB for ~3.5 months of use (~150 MB/month at current pace).

--- a/docs/claude-session-analysis.md
+++ b/docs/claude-session-analysis.md
@@ -167,7 +167,48 @@ appearing in **both** models are clean signals for style comparison.
 
 ---
 
-## 4. Privacy note
+## 4. Thinking blocks — what's stored and what isn't
+
+### Thinking content is redacted on disk
+
+Extended thinking blocks (`type: "thinking"`) are stored as placeholders: only
+a `signature` hash is written, the actual reasoning text is wiped before saving.
+
+```json
+{ "type": "thinking", "signature": "ErUv...", "thinking": "" }
+```
+
+This means the JSONL files record *that* thinking happened and *how often*, but
+not *what* was thought. You can count invocations; you cannot read the reasoning.
+
+### Thinking invocation rate by model
+
+| Model | Text blocks | Text median (words) | Think blocks | Think % |
+|---|---:|---:|---:|---:|
+| opus-4-5 | 189 | 12 | 9 | 4.5% |
+| haiku-4-5 | 4,959 | 13 | 0 | 0% |
+| sonnet-4-5 | 216 | 16 | 0 | 0% |
+| sonnet-4-6 | 197 | 17 | 8 | 3.9% |
+| **opus-4-6** | 8,112 | **21** | 1,049 | **11.5%** |
+| **opus-4-7** | 1,283 | **51** | 1,762 | **57.9%** |
+
+Thinking switched on from 2026-03-25 when opus-4-6 became the primary model.
+Invocation volume spiked on 2026-04-12 (228 in one day, still opus-4-6) then
+jumped again from 2026-04-21 when opus-4-7 took over.
+
+### Internalising reasoning made visible output longer, not shorter
+
+The intuition "hidden thinking = more concise visible replies" is wrong in
+practice. Opus 4-7 writes **51-word median visible responses** vs 4-6's **21
+words** — 2.4× longer — while also invoking thinking nearly 6× more often.
+
+The thinking is additive, not a replacement for visible explanation. 4-7 both
+thinks more (hidden) and says more (visible). What it drops is the *narration*
+("Now let me check…", "Let me also look at…") — style, not volume.
+
+---
+
+## 5. Privacy note
 
 Session JSONL files contain the full text of every prompt you sent and every
 response Claude generated, including file contents pasted as context and

--- a/docs/claude-telemetry.md
+++ b/docs/claude-telemetry.md
@@ -1,0 +1,179 @@
+# Claude Code Telemetry & Multi-Machine Aggregation — Plan
+
+Notes from an exploration of how to track Claude Code cost / tokens / tool
+usage across machines, and how that interacts with [codeburn][cb].
+
+[cb]: https://github.com/thompsonson/codeburn
+
+## TL;DR — do this in order
+
+1. **Run the diagnostic in §1** before building anything. It answers whether
+   "only ~1 month showing in codeburn" is data loss or display windowing —
+   the answer changes what's worth doing next.
+2. **Add `~/.claude/projects/` to `sysbak`** (§2). Solves retention
+   independently of any tooling choice.
+3. **Decide on aggregation** (§3) only if step 1 confirms multiple machines
+   each hold sessions worth merging.
+4. **OTel telemetry env vars** (§4) are optional and orthogonal — only
+   useful if you'll actually look at dashboards.
+
+---
+
+## 1. Diagnostic — what's actually on disk?
+
+Claude Code stores session transcripts as JSONL at
+`~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. There's no evidence
+Claude rotates them, so files going back >1 month should be present unless
+something else removed them.
+
+Run on your laptop:
+
+```bash
+#!/usr/bin/env bash
+# Inventory ~/.claude session storage.
+# Distinguishes "data is gone" from "codeburn is windowing the display".
+
+set -u
+DIR="${CLAUDE_DIR:-$HOME/.claude/projects}"
+
+if [ ! -d "$DIR" ]; then
+  echo "No $DIR — Claude Code not installed or session dir is elsewhere."
+  exit 1
+fi
+
+echo "=== Inventory: $DIR ==="
+files=$(find "$DIR" -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')
+projects=$(find "$DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+echo "$files session files across $projects project dirs"
+du -sh "$DIR" 2>/dev/null
+
+echo
+echo "=== Sessions older than... (by mtime) ==="
+for d in 30 60 90 180 365 730; do
+  n=$(find "$DIR" -name '*.jsonl' -mtime +$d 2>/dev/null | wc -l | tr -d ' ')
+  printf "  %4d days: %5s files\n" "$d" "$n"
+done
+
+echo
+echo "=== Newest / oldest by mtime ==="
+find "$DIR" -name '*.jsonl' 2>/dev/null -print0 \
+  | xargs -0 ls -lt 2>/dev/null \
+  | awk 'NR==1 {newest=$0} {oldest=$0} END {print "newest:", newest; print "oldest:", oldest}'
+
+echo
+echo "=== Largest projects ==="
+du -sh "$DIR"/*/ 2>/dev/null | sort -h | tail -10
+```
+
+### How to read the output
+
+| What you see | What it means | Next step |
+|---|---|---|
+| Files >30d old exist, codeburn UI shows ~1 month | codeburn is windowing the display | Check codeburn flags / config for the lookback window |
+| Few/no files >30d old, total size small | Data was removed (reinstall, cleanup, migration) | Restore from backup if you have one; treat retention as a backup problem from now on (§2) |
+| Lots of files but only one or two project dirs | You changed `cwd`s a lot or only used one project — probably fine | — |
+
+mtime is a first approximation: if you've copied files between machines it
+can lie. For a deeper check, the JSONL files contain per-event timestamps
+inside — parseable with `jq` if needed.
+
+---
+
+## 2. Backup retention — do this regardless
+
+Whatever aggregation choice you make, the retention story should not depend
+on it. Add `~/.claude/projects/` (and `~/.claude/sessions/` if you care about
+metadata) to `sysbak`'s include list so the USB rsnapshot rotation owns
+historical session data.
+
+Once that's in place, "how far back can I see?" becomes "however far back
+your backup chain goes," not a tooling concern.
+
+---
+
+## 3. Cross-machine aggregation
+
+Only worth building if you actually run Claude on multiple machines and
+want one combined view. If `pop-mini` is the only Claude host, skip this
+and just `ssh pop-mini codeburn` from elsewhere.
+
+### Recommended shape: sync-to-laptop, pull model
+
+- **Laptop is the aggregator.** Runs codeburn against a tree containing
+  its own sessions plus copies pulled from each remote host.
+- **Pull, not push.** A launchd timer on the laptop rsyncs from each
+  device over Tailscale/SSH on a schedule (e.g. every 15 min). Pull
+  handles "remote was offline" gracefully — next tick catches up. Push
+  from remotes has to deal with "laptop closed" and needs retry logic.
+- **Namespace per host, do not merge.** Pull into
+  `~/.claude-aggregated/<hostname>/projects/`, never into
+  `~/.claude/projects/`. Reasons:
+    - Keeps your live Claude Code untouched (no chance of seeing foreign
+      sessions in the running client).
+    - Gives you a free `(machine_id, session_id)` key via the directory
+      name — handles dedup if you ever ssh into another host and run
+      Claude there.
+    - Easy to wipe and re-sync if anything goes wrong.
+- **codeburn must support multiple roots.** Verify before designing the
+  rest. If it only reads `~/.claude/projects/`, either (a) PR a
+  `--scan-root` / env var, or (b) symlink children of the aggregated
+  tree under a single shadow root.
+
+### Why not "pop-mini as a server"
+
+codeburn today is a *parser* (reads provider session files from disk),
+not a *receiver*. Turning it into a server/client app means designing:
+an ingest API, schema versioning, auth tokens, retry/backoff on the
+client, dedup keys, a fan-out for new providers. That's weeks of work.
+
+Sync-to-laptop reuses 100% of the existing parser and is days of work
+(launchd plist + rsync wrapper + multi-root scan). You can graduate to
+real client/server later if file-sync hits a wall — e.g. you want
+sub-minute freshness or non-Unix clients.
+
+### Open questions to nail down before any code
+
+- **Menubar offline behaviour** — when the laptop is off-network, does
+  the menubar show stale-cached data, blank, or fall back to a local
+  parse? Decide now; affects how the read path is structured.
+- **Cursor SQLite** — codeburn parses Cursor's SQLite DB. Syncing a live
+  SQLite file is fine with WAL mode + rsync, but worth a sanity check
+  that the parser tolerates a snapshot taken mid-write.
+
+---
+
+## 4. (Optional) OTel telemetry env vars
+
+Orthogonal to all of the above. Useful if you want *live* metrics (cost,
+tokens by model, tool success/failure, lines-of-code, commits, PRs) flowing
+to a dashboard rather than reconstructed from JSONL after the fact.
+
+```bash
+# In ~/.zshrc, ideally guarded by a per-machine opt-in toggle:
+if [ -f "$HOME/.config/claude-telemetry/enabled" ]; then
+  export CLAUDE_CODE_ENABLE_TELEMETRY=1
+  export OTEL_METRICS_EXPORTER=otlp
+  export OTEL_LOGS_EXPORTER=otlp
+  export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+fi
+```
+
+The receiver options, lightest first:
+
+- `OTEL_METRICS_EXPORTER=console` — prints to terminal. Good for sanity
+  checks, useless for trends.
+- **Custom OTel→SQLite bridge** — ~100 lines of Python listening on
+  `:4317`, inserting into one file. Fits the dotfiles ethos; you own
+  the schema and retention.
+- **Anthropic's `claude-code-monitoring-guide` Docker stack** —
+  Prometheus + Loki + Grafana with pre-built dashboards. Heaviest
+  option; only worth it if you'll genuinely watch dashboards.
+
+Defaults to leave alone unless you have a reason: `OTEL_LOG_TOOL_DETAILS`
+(off — fattens logs fast), `OTEL_LOG_USER_PROMPTS` (off — privacy / size),
+`OTEL_LOG_RAW_API_BODIES` (off — size).
+
+Note: Claude Code already has `/cost` for session-level spend with zero
+setup, and the Anthropic Console is the source of truth for billing. If
+cost is the only thing you care about, those two cover it.


### PR DESCRIPTION
## Summary
- `docs/claude-session-analysis.md` — session storage inventory (popmini, 2026-04-28), phrase frequency analysis, thinking-block patterns
- `docs/claude-telemetry.md` — multi-machine aggregation plan, OTel env vars, diagnostic script
- `dot_local/bin/executable_sysup` — add `codeburn` to `tools_cli` in doctor check

## Context
Analysis produced while adding tool analytics to [thompsonson/codeburn](https://github.com/thompsonson/codeburn). Documents retained as reference for future workflow-service integration.