### PR TITLE
fix(codeburn): install v0.9.1-thompsonson.2 from fork

### DIFF
--- a/run_once_after_install-codeburn.sh
+++ b/run_once_after_install-codeburn.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+# Install codeburn from fork (thompsonson/codeburn)
+# Runs once per machine; re-runs if this file changes (e.g. version bump).
+
+set -euo pipefail
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo 'codeburn: npm not found, skipping'
+  exit 0
+fi
+
+echo 'Installing codeburn from thompsonson/codeburn...'
+npm install -g thompsonson/codeburn#v0.9.1-thompsonson.2
+echo "codeburn installed: $(codeburn --version 2>/dev/null || echo 'unknown version')"


### PR DESCRIPTION
## Summary
Bump codeburn install tag to `v0.9.1-thompsonson.2`.

## Why
`v0.9.1-thompsonson.1` failed on fresh machines — `npm install -g` from GitHub doesn't install devDependencies before running `prepare`, so `tsup` was missing. `v0.9.1-thompsonson.2` ships a pre-built `dist/` so no build step is needed at install time.

See thompsonson/codeburn#6 and thompsonson/codeburn#7.