### PR TITLE
fix(codeburn): bump to v0.9.1-thompsonson.3; add to sysup doctor

### DIFF
--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -579,7 +579,7 @@ cmd_doctor() {
   done
 
   header "Modern CLI Replacements"
-  local tools_cli=(eza bat fd rg delta btop zoxide jq sensors sar yq pandoc ffmpeg yt-dlp)
+  local tools_cli=(eza bat fd rg delta btop zoxide jq sensors sar yq pandoc ffmpeg yt-dlp codeburn)
   for tool in "${tools_cli[@]}"; do
     check_tool "$tool"
   done

--- a/run_once_after_install-codeburn.sh
+++ b/run_once_after_install-codeburn.sh
@@ -10,5 +10,5 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 
 echo 'Installing codeburn from thompsonson/codeburn...'
-npm install -g thompsonson/codeburn#v0.9.1-thompsonson.2
+npm install -g thompsonson/codeburn#v0.9.1-thompsonson.3
 echo "codeburn installed: $(codeburn --version 2>/dev/null || echo 'unknown version')"


### PR DESCRIPTION
## Summary
- Bump install tag to `v0.9.1-thompsonson.3` — uses `npx --yes tsup` in `prepare`, no pre-built dist in repo
- Add `codeburn` to `tools_cli` in `sysup doctor` (was dropped from #53 squash)

## Why
`v0.9.1-thompsonson.2` shipped a pre-built `dist/` as a workaround. `v0.9.1-thompsonson.3` fixes the root cause (thompsonson/codeburn#7) so the install builds correctly on any machine without dist in git.