### PR TITLE
fix(codeburn): install from release tarball URL

### DIFF
--- a/run_once_after_install-codeburn.sh
+++ b/run_once_after_install-codeburn.sh
@@ -10,5 +10,5 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 
 echo 'Installing codeburn from thompsonson/codeburn...'
-npm install -g thompsonson/codeburn#v0.9.1-thompsonson.3
+npm install -g https://github.com/thompsonson/codeburn/releases/download/v0.9.1-thompsonson.4/codeburn.tgz
 echo "codeburn installed: $(codeburn --version 2>/dev/null || echo 'unknown version')"


### PR DESCRIPTION
Switches from `npm install -g <github-url>#<tag>` to installing from the pre-built release tarball:

```
npm install -g https://github.com/thompsonson/codeburn/releases/download/v0.9.1-thompsonson.4/codeburn.tgz
```

Tarball is built by CI on tag push (thompsonson/codeburn#9). No build step at install time — bypasses all npm GitHub install issues.