### PR TITLE
feat(claude-chains): tool-chain sequence extractor + codeburn install fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 # But include chezmoi-managed bin directories
 !executable_*/bin/
 !dot_*/bin/
+
+output/

--- a/docs/claude-telemetry-strategy.md
+++ b/docs/claude-telemetry-strategy.md
@@ -1,0 +1,91 @@
+# Claude Code Telemetry — Why and What Good Looks Like
+
+## Purpose
+
+This telemetry pipeline serves two connected goals:
+
+**1. Personal development analytics**
+As the sole developer and CTO of Manta Technologies, understand where Claude Code time is actually spent — across Manta repos, AtomicGuard, and personal tooling. Weekly and monthly retros, not live dashboards.
+
+**2. Empirical input to workflow-service**
+Claude Code's tool chains are real-world evidence of recurring workflows. A session that consistently runs `git commit → gh pr create → gh run watch` is a workflow that exists in practice. The telemetry pipeline captures these patterns so they can be registered in `workflow-service` — grounding its intent registry in observed behaviour rather than guesswork.
+
+The connection: **Claude Code produces tool chains → telemetry captures them → analysis reveals patterns → patterns become registered workflows → workflow-service routes voice/agent inputs to those workflows → atomicguard validates execution.**
+
+---
+
+## What this is not
+
+- Not an enterprise observability system
+- Not real-time dashboards or alerting
+- Not a replacement for Anthropic Console billing data
+- Not multi-user or shared infrastructure
+
+This is a lightweight personal tool: one Docker container, one SQLite file, a few Python scripts.
+
+---
+
+## The pipeline
+
+```
+Claude Code (any machine)
+  │  CLAUDE_CODE_ENABLE_TELEMETRY=1
+  │  OTEL_EXPORTER_OTLP_ENDPOINT → pop-mini:4318
+  ▼
+otelcol-contrib (Docker, pop-mini)
+  │  file exporter → JSONL rotation
+  ▼
+ingest.py (systemd timer, every 5 min)
+  │  byte-offset tracking, idempotent
+  ▼
+claude.db → table: events          ← live OTel forward stream
+
+~/.claude/projects/**/*.jsonl      ← existing transcripts
+  │  backfill.py (one-shot, idempotent)
+  ▼
+claude.db → table: legacy_events   ← historical data (back to Jan 2026)
+
+claude-chains.py                   ← tool-sequence n-gram analysis (standalone)
+otel-stats                         ← SQL presets for retros
+```
+
+---
+
+## What good looks like
+
+### Personal analytics (done when...)
+- `otel-stats hours-per-week --since=2026-01-01` gives a reliable weekly active-time view across all projects
+- `otel-stats by-project` shows where effort is concentrated across Manta vs AtomicGuard vs tooling
+- Token totals per day are queryable — giving a cost-proxy without hitting the Anthropic Console
+
+### Workflow-service input (done when...)
+- `claude-chains.py --summary-only --since 30` reliably surfaces the top 20 tool n-grams
+- At least 3 recurring patterns are clearly identifiable (e.g. `git → gh pr create`, `Read → Edit → Bash`, `Agent → git → gh`)
+- Those patterns are written up as candidate workflow registrations in `workflow-service`
+- The connection between "observed in telemetry" and "registered in workflow-service" is documented in that repo
+
+### Ongoing health (done when...)
+- `otel-ingest.timer` runs reliably on pop-mini with no manual intervention
+- New machines can opt in by touching `~/.config/claude-telemetry/enabled`
+- `sysbak` covers `~/.local/share/otel/data/` so the SQLite store is backed up
+
+---
+
+## Key questions this should answer
+
+| Question | Source |
+|---|---|
+| How many hours per week am I using Claude Code? | `otel-stats hours-per-week` |
+| Which projects take the most time? | `otel-stats by-project` |
+| What are the most common tool sequences? | `claude-chains.py --summary-only` |
+| Which tools fail most often? | `otel-stats by-tool` + error analysis |
+| Which workflows recur enough to register? | n-gram analysis → workflow-service |
+| How does usage split across Manta vs AtomicGuard? | `--project` filter on any preset |
+
+---
+
+## Related docs
+
+- [`claude-telemetry.md`](claude-telemetry.md) — ops reference: setup, activation, network, operations
+- [`claude-session-analysis.md`](claude-session-analysis.md) — historical analysis (Apr 2026 baseline)
+- [`workflow-service`](https://github.com/thompsonson/workflow-service) — the downstream consumer of workflow patterns

--- a/run_once_after_install-codeburn.sh
+++ b/run_once_after_install-codeburn.sh
@@ -10,5 +10,5 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 
 echo 'Installing codeburn from thompsonson/codeburn...'
-npm install -g thompsonson/codeburn#v0.9.1-thompsonson.3
+npm install -g https://github.com/thompsonson/codeburn/releases/download/v0.9.1-thompsonson.4/codeburn.tgz
 echo "codeburn installed: $(codeburn --version 2>/dev/null || echo 'unknown version')"

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -10,6 +10,8 @@ Usage:
     python3 scripts/claude-chains.py --since 30
     python3 scripts/claude-chains.py --project atomicguard --since 7
     python3 scripts/claude-chains.py --output /tmp/chains-7d.jsonl
+    python3 scripts/claude-chains.py --html /tmp/chains.html
+    python3 scripts/claude-chains.py --markdown /tmp/chains.md
     python3 scripts/claude-chains.py --summary-only
 """
 
@@ -18,35 +20,30 @@ import json
 import sys
 import time
 from collections import Counter
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
 
 CLAUDE_DIR = Path.home() / ".claude" / "projects"
-OUTPUT_DIR = Path("output")
 
 _BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
 
 
 def bash_label(command: str) -> str:
-    """Return the effective command name from a Bash input.command string."""
     if not command:
         return "_shell"
     words = command.split()
     for word in words:
         if word in _BASH_WRAPPERS:
             continue
-        # Skip env VAR=value tokens
         if "=" in word and not word.startswith("-"):
             continue
         if word.startswith("$") or word.startswith("{"):
             return "_shell"
-        # Strip path prefix: /usr/bin/git -> git
         return Path(word).name or "_shell"
     return "_shell"
 
 
 def extract_tool_label(block: dict) -> str:
-    """Return a label for a tool_use block."""
     name = block.get("name", "")
     if name == "Bash":
         cmd = block.get("input", {}).get("command", "")
@@ -55,9 +52,8 @@ def extract_tool_label(block: dict) -> str:
 
 
 def parse_session(path: Path) -> dict | None:
-    """Parse a session JSONL file into a sequence record. Returns None on error."""
     turns: list[dict] = []
-    session_id = path.stem  # filename without .jsonl
+    session_id = path.stem
 
     try:
         with open(path) as f:
@@ -73,7 +69,6 @@ def parse_session(path: Path) -> dict | None:
                 if obj.get("type") != "assistant":
                     continue
 
-                # Timestamp is top-level on the record
                 ts = obj.get("timestamp", "")
                 uuid = obj.get("uuid", "")
                 content = obj.get("message", {}).get("content", [])
@@ -112,7 +107,6 @@ def parse_session(path: Path) -> dict | None:
 
 
 def discover_sessions(since_days: int, project: str | None) -> list[Path]:
-    """Return .jsonl session files modified within since_days, optionally filtered by project."""
     if not CLAUDE_DIR.exists():
         return []
 
@@ -135,18 +129,183 @@ def ngrams(stream: list[str], n: int) -> list[tuple[str, ...]]:
     return [tuple(stream[i : i + n]) for i in range(len(stream) - n + 1)]
 
 
-def summarise(records: list[dict], top_n: int = 20) -> None:
+def compute_ngrams(records: list[dict], top_n: int = 20) -> list[tuple[tuple, int]]:
     counts: Counter = Counter()
     for rec in records:
         flat = [t for turn in rec["sequence"] for t in turn["tools"]]
         for n in (2, 3, 4):
             counts.update(ngrams(flat, n))
+    return counts.most_common(top_n)
 
+
+def project_stats(records: list[dict]) -> list[tuple[str, int, int]]:
+    """Return (project_key, session_count, turn_count) sorted by sessions desc."""
+    by_project: dict[str, list[int]] = {}
+    for rec in records:
+        pk = rec["project_key"]
+        by_project.setdefault(pk, []).append(rec["turns"])
+    return sorted(
+        [(pk, len(turns), sum(turns)) for pk, turns in by_project.items()],
+        key=lambda x: x[1],
+        reverse=True,
+    )
+
+
+def summarise(records: list[dict], top_n: int = 20) -> None:
+    top = compute_ngrams(records, top_n)
     print(f"\nTop {top_n} tool n-grams (size 2–4) across {len(records)} sessions:\n")
     print(f"  {'Count':>6}  Pattern")
     print(f"  {'------':>6}  -------")
-    for pattern, count in counts.most_common(top_n):
+    for pattern, count in top:
         print(f"  {count:>6}  {' → '.join(pattern)}")
+
+
+def write_html(records: list[dict], path: Path, since_days: int) -> None:
+    top = compute_ngrams(records, 20)
+    stats = project_stats(records)
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    labels_js = json.dumps([" → ".join(p) for p, _ in top])
+    counts_js = json.dumps([c for _, c in top])
+    proj_labels_js = json.dumps([pk.replace("-home-mt-Projects-", "").replace("-home-mt-", "") for pk, _, _ in stats])
+    proj_sessions_js = json.dumps([s for _, s, _ in stats])
+    proj_turns_js = json.dumps([t for _, _, t in stats])
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Claude Code Tool Chains</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+  body {{ font-family: system-ui, sans-serif; background: #0d1117; color: #e6edf3; margin: 0; padding: 24px; }}
+  h1 {{ font-size: 1.4rem; margin-bottom: 4px; }}
+  .meta {{ color: #8b949e; font-size: 0.85rem; margin-bottom: 32px; }}
+  .grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }}
+  .card {{ background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; }}
+  .card h2 {{ font-size: 1rem; margin: 0 0 16px; color: #e6edf3; }}
+  canvas {{ max-height: 420px; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; margin-top: 12px; }}
+  th {{ text-align: left; color: #8b949e; border-bottom: 1px solid #30363d; padding: 6px 8px; }}
+  td {{ padding: 5px 8px; border-bottom: 1px solid #21262d; }}
+  .num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+</style>
+</head>
+<body>
+<h1>Claude Code Tool Chains</h1>
+<p class="meta">Last {since_days} days &middot; {len(records)} sessions &middot; generated {generated}</p>
+<div class="grid">
+  <div class="card" style="grid-column: 1 / -1;">
+    <h2>Top 20 Tool N-grams (size 2–4)</h2>
+    <canvas id="ngram"></canvas>
+  </div>
+  <div class="card">
+    <h2>Sessions by Project</h2>
+    <canvas id="proj"></canvas>
+  </div>
+  <div class="card">
+    <h2>N-gram Table</h2>
+    <table>
+      <tr><th>Pattern</th><th class="num">Count</th></tr>
+      {''.join(f'<tr><td>{" → ".join(p)}</td><td class="num">{c}</td></tr>' for p, c in top)}
+    </table>
+  </div>
+</div>
+<script>
+const ngLabels = {labels_js};
+const ngCounts = {counts_js};
+const projLabels = {proj_labels_js};
+const projSessions = {proj_sessions_js};
+const projTurns = {proj_turns_js};
+
+new Chart(document.getElementById('ngram'), {{
+  type: 'bar',
+  data: {{
+    labels: ngLabels,
+    datasets: [{{ label: 'Occurrences', data: ngCounts,
+      backgroundColor: 'rgba(88,166,255,0.7)', borderRadius: 4 }}]
+  }},
+  options: {{
+    indexAxis: 'y',
+    plugins: {{ legend: {{ display: false }} }},
+    scales: {{
+      x: {{ grid: {{ color: '#21262d' }}, ticks: {{ color: '#8b949e' }} }},
+      y: {{ grid: {{ display: false }}, ticks: {{ color: '#e6edf3', font: {{ family: 'monospace' }} }} }}
+    }}
+  }}
+}});
+
+new Chart(document.getElementById('proj'), {{
+  type: 'bar',
+  data: {{
+    labels: projLabels,
+    datasets: [
+      {{ label: 'Sessions', data: projSessions, backgroundColor: 'rgba(63,185,80,0.7)', borderRadius: 4 }},
+      {{ label: 'Turns', data: projTurns, backgroundColor: 'rgba(210,153,34,0.5)', borderRadius: 4 }}
+    ]
+  }},
+  options: {{
+    plugins: {{ legend: {{ labels: {{ color: '#8b949e' }} }} }},
+    scales: {{
+      x: {{ grid: {{ color: '#21262d' }}, ticks: {{ color: '#8b949e', font: {{ family: 'monospace', size: 11 }} }}, maxRotation: 45 }},
+      y: {{ grid: {{ color: '#21262d' }}, ticks: {{ color: '#8b949e' }} }}
+    }}
+  }}
+}});
+</script>
+</body>
+</html>"""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(html + "\n")
+    print(f"HTML:     {path}")
+
+
+def write_markdown(records: list[dict], path: Path, since_days: int) -> None:
+    top = compute_ngrams(records, 20)
+    stats = project_stats(records)
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    # Mermaid xychart-beta supports up to ~10 bars cleanly
+    top10 = top[:10]
+    mermaid_labels = [f'"{" → ".join(p)}"' for p, _ in top10]
+    mermaid_counts = [str(c) for _, c in top10]
+
+    lines = [
+        "# Claude Code Tool Chains",
+        "",
+        f"_Last {since_days} days · {len(records)} sessions · generated {generated}_",
+        "",
+        "## Top 10 N-grams",
+        "",
+        "```mermaid",
+        "xychart-beta horizontal",
+        f'    x-axis [{", ".join(mermaid_labels)}]',
+        f'    bar [{", ".join(mermaid_counts)}]',
+        "```",
+        "",
+        "## Full Top 20 N-gram Table",
+        "",
+        "| Pattern | Count |",
+        "|---------|------:|",
+    ]
+    for pattern, count in top:
+        lines.append(f"| `{' → '.join(pattern)}` | {count} |")
+
+    lines += [
+        "",
+        "## Sessions by Project",
+        "",
+        "| Project | Sessions | Turns |",
+        "|---------|--------:|------:|",
+    ]
+    for pk, sessions, turns in stats:
+        short = pk.replace("-home-mt-Projects-", "").replace("-home-mt-", "")
+        lines.append(f"| `{short}` | {sessions} | {turns} |")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+    print(f"Markdown: {path}")
 
 
 def main() -> None:
@@ -157,8 +316,12 @@ def main() -> None:
                         help="Filter by substring of encoded project dir name")
     parser.add_argument("--output", metavar="FILE",
                         help="Write per-session JSONL to this path")
+    parser.add_argument("--html", metavar="FILE",
+                        help="Write self-contained HTML visualisation to this path")
+    parser.add_argument("--markdown", metavar="FILE",
+                        help="Write GitHub-renderable Mermaid markdown to this path")
     parser.add_argument("--summary-only", action="store_true",
-                        help="Print n-gram summary only (ignores --output)")
+                        help="Print n-gram summary only (ignores --output/--html/--markdown)")
     args = parser.parse_args()
 
     paths = discover_sessions(args.since, args.project)
@@ -176,13 +339,18 @@ def main() -> None:
         print("No tool-call sequences found in selected sessions.", file=sys.stderr)
         sys.exit(1)
 
-    if not args.summary_only and args.output:
-        out_path = Path(args.output)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(out_path, "w") as f:
-            for rec in records:
-                f.write(json.dumps(rec) + "\n")
-        print(f"Wrote {len(records)} session records to {out_path}")
+    if not args.summary_only:
+        if args.output:
+            out_path = Path(args.output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(out_path, "w") as f:
+                for rec in records:
+                    f.write(json.dumps(rec) + "\n")
+            print(f"JSONL:    {out_path}")
+        if args.html:
+            write_html(records, Path(args.html), args.since)
+        if args.markdown:
+            write_markdown(records, Path(args.markdown), args.since)
 
     summarise(records)
 

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -75,8 +75,6 @@ def bash_label(command: str, subcommands: bool = False) -> str:
         if word.startswith("#"):
             return "_shell"
         effective.append(Path(word).name if not effective else word)
-        if not effective:
-            continue
         break
     if not effective:
         return "_shell"

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -34,7 +34,7 @@ _BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
 _SUBCOMMAND_DEPTH: dict[str, int] = {
     "gh": 3,
     "git": 2,
-    "uv": 2,
+    "uv": 2,       # uv sync, uv add, uv lock — uv run handled by _TRANSPARENT_RUNNERS
     "docker": 2,
     "just": 2,
     "chezmoi": 2,
@@ -42,6 +42,21 @@ _SUBCOMMAND_DEPTH: dict[str, int] = {
     "kubectl": 2,
     "cargo": 2,
     "npm": 2,
+}
+
+# CLIs that act as transparent runners: `uv run python` → label is `python`.
+# The word after the subcommand becomes the effective label.
+_TRANSPARENT_RUNNERS: dict[str, str] = {
+    "uv": "run",    # uv run <cmd> → <cmd>
+}
+
+# Normalise variant spellings to a canonical label.
+_LABEL_ALIASES: dict[str, str] = {
+    "python3": "python",
+    "python3.10": "python",
+    "python3.11": "python",
+    "python3.12": "python",
+    "python3.13": "python",
 }
 
 
@@ -67,30 +82,39 @@ def bash_label(command: str, subcommands: bool = False) -> str:
         return "_shell"
 
     cli = effective[0]
-    if not subcommands or cli not in _SUBCOMMAND_DEPTH:
-        return cli
+
+    if not subcommands:
+        return _LABEL_ALIASES.get(cli, cli)
+
+    # Transparent runners: `uv run python` → `python`
+    if cli in _TRANSPARENT_RUNNERS:
+        trigger = _TRANSPARENT_RUNNERS[cli]
+        raw_words = command.split()
+        idx = next(
+            (i for i, w in enumerate(raw_words) if w not in _BASH_WRAPPERS and "=" not in w),
+            0,
+        )
+        tail = [w for w in raw_words[idx + 1:] if not w.startswith("-") and "=" not in w]
+        if tail and tail[0] == trigger and len(tail) > 1:
+            inner = Path(tail[1]).name
+            return _LABEL_ALIASES.get(inner, inner)
+        # Fall through to depth-based logic (uv sync, uv add, etc.)
+
+    if cli not in _SUBCOMMAND_DEPTH:
+        return _LABEL_ALIASES.get(cli, cli)
 
     # Collect up to depth words, stopping at flags
     depth = _SUBCOMMAND_DEPTH[cli]
     parts = [cli]
-    remaining = [w for w in words[words.index(command.split()[0]) + 1:] if w]
-    # Re-derive from original words after wrappers
     raw_words = command.split()
-    idx = 0
-    # Skip wrappers/env-vars to find CLI position
-    for i, w in enumerate(raw_words):
-        if w in _BASH_WRAPPERS:
-            continue
-        if "=" in w and not w.startswith("-"):
-            continue
-        idx = i
-        break
+    idx = next(
+        (i for i, w in enumerate(raw_words) if w not in _BASH_WRAPPERS and "=" not in w),
+        0,
+    )
     for w in raw_words[idx + 1:]:
         if len(parts) >= depth:
             break
-        if w.startswith("-"):
-            break
-        if "=" in w and not w.startswith("-"):
+        if w.startswith("-") or ("=" in w and not w.startswith("-")):
             break
         parts.append(w)
 
@@ -184,7 +208,7 @@ def ngrams(stream: list[str], n: int) -> list[tuple[str, ...]]:
     return [tuple(stream[i : i + n]) for i in range(len(stream) - n + 1)]
 
 
-def compute_ngrams(records: list[dict], top_n: int = 20) -> list[tuple[tuple, int]]:
+def compute_ngrams(records: list[dict], top_n: int = 50) -> list[tuple[tuple, int]]:
     counts: Counter = Counter()
     for rec in records:
         flat = [t for turn in rec["sequence"] for t in turn["tools"]]
@@ -206,7 +230,7 @@ def project_stats(records: list[dict]) -> list[tuple[str, int, int]]:
     )
 
 
-def summarise(records: list[dict], top_n: int = 20) -> None:
+def summarise(records: list[dict], top_n: int = 50) -> None:
     top = compute_ngrams(records, top_n)
     print(f"\nTop {top_n} tool n-grams (size 2–4) across {len(records)} sessions:\n")
     print(f"  {'Count':>6}  Pattern")

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Extract tool-call sequences from Claude Code session JSONL files.
+
+Discovers ~/.claude/projects/**/*.jsonl, parses assistant turns, and emits
+per-session JSONL with ordered tool sequences. Prints a top-20 n-gram summary.
+
+Usage:
+    python3 scripts/claude-chains.py
+    python3 scripts/claude-chains.py --since 30
+    python3 scripts/claude-chains.py --project atomicguard --since 7
+    python3 scripts/claude-chains.py --output /tmp/chains-7d.jsonl
+    python3 scripts/claude-chains.py --summary-only
+"""
+
+import argparse
+import json
+import sys
+import time
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+CLAUDE_DIR = Path.home() / ".claude" / "projects"
+OUTPUT_DIR = Path("output")
+
+_BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
+
+
+def bash_label(command: str) -> str:
+    """Return the effective command name from a Bash input.command string."""
+    if not command:
+        return "_shell"
+    words = command.split()
+    for word in words:
+        if word in _BASH_WRAPPERS:
+            continue
+        # Skip env VAR=value tokens
+        if "=" in word and not word.startswith("-"):
+            continue
+        if word.startswith("$") or word.startswith("{"):
+            return "_shell"
+        # Strip path prefix: /usr/bin/git -> git
+        return Path(word).name or "_shell"
+    return "_shell"
+
+
+def extract_tool_label(block: dict) -> str:
+    """Return a label for a tool_use block."""
+    name = block.get("name", "")
+    if name == "Bash":
+        cmd = block.get("input", {}).get("command", "")
+        return bash_label(cmd)
+    return name
+
+
+def parse_session(path: Path) -> dict | None:
+    """Parse a session JSONL file into a sequence record. Returns None on error."""
+    turns: list[dict] = []
+    session_id = path.stem  # filename without .jsonl
+
+    try:
+        with open(path) as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                if obj.get("type") != "assistant":
+                    continue
+
+                # Timestamp is top-level on the record
+                ts = obj.get("timestamp", "")
+                uuid = obj.get("uuid", "")
+                content = obj.get("message", {}).get("content", [])
+
+                if not isinstance(content, list):
+                    continue
+
+                tool_labels = [
+                    extract_tool_label(b)
+                    for b in content
+                    if isinstance(b, dict) and b.get("type") == "tool_use"
+                ]
+
+                if not tool_labels:
+                    continue
+
+                turns.append({"ts": ts, "uuid": uuid[:8], "tools": tool_labels})
+
+    except OSError:
+        return None
+
+    if not turns:
+        return None
+
+    turns.sort(key=lambda t: t["ts"])
+    project_key = path.parent.name
+
+    return {
+        "session_id": session_id,
+        "project_key": project_key,
+        "first_ts": turns[0]["ts"],
+        "last_ts": turns[-1]["ts"],
+        "turns": len(turns),
+        "sequence": turns,
+    }
+
+
+def discover_sessions(since_days: int, project: str | None) -> list[Path]:
+    """Return .jsonl session files modified within since_days, optionally filtered by project."""
+    if not CLAUDE_DIR.exists():
+        return []
+
+    cutoff = time.time() - since_days * 86400
+    paths = []
+
+    for project_dir in CLAUDE_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        if project and project not in project_dir.name:
+            continue
+        for f in project_dir.glob("*.jsonl"):
+            if f.stat().st_mtime >= cutoff:
+                paths.append(f)
+
+    return sorted(paths)
+
+
+def ngrams(stream: list[str], n: int) -> list[tuple[str, ...]]:
+    return [tuple(stream[i : i + n]) for i in range(len(stream) - n + 1)]
+
+
+def summarise(records: list[dict], top_n: int = 20) -> None:
+    counts: Counter = Counter()
+    for rec in records:
+        flat = [t for turn in rec["sequence"] for t in turn["tools"]]
+        for n in (2, 3, 4):
+            counts.update(ngrams(flat, n))
+
+    print(f"\nTop {top_n} tool n-grams (size 2–4) across {len(records)} sessions:\n")
+    print(f"  {'Count':>6}  Pattern")
+    print(f"  {'------':>6}  -------")
+    for pattern, count in counts.most_common(top_n):
+        print(f"  {count:>6}  {' → '.join(pattern)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract Claude Code tool-call sequences")
+    parser.add_argument("--since", type=int, default=7, metavar="DAYS",
+                        help="Include sessions modified within N days (default: 7)")
+    parser.add_argument("--project", metavar="SUBSTR",
+                        help="Filter by substring of encoded project dir name")
+    parser.add_argument("--output", metavar="FILE",
+                        help="Write per-session JSONL to this path")
+    parser.add_argument("--summary-only", action="store_true",
+                        help="Print n-gram summary only (ignores --output)")
+    args = parser.parse_args()
+
+    paths = discover_sessions(args.since, args.project)
+    if not paths:
+        print("No session files found.", file=sys.stderr)
+        sys.exit(1)
+
+    records = []
+    for p in paths:
+        rec = parse_session(p)
+        if rec:
+            records.append(rec)
+
+    if not records:
+        print("No tool-call sequences found in selected sessions.", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.summary_only and args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as f:
+            for rec in records:
+                f.write(json.dumps(rec) + "\n")
+        print(f"Wrote {len(records)} session records to {out_path}")
+
+    summarise(records)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -13,6 +13,7 @@ Usage:
     python3 scripts/claude-chains.py --html /tmp/chains.html
     python3 scripts/claude-chains.py --markdown /tmp/chains.md
     python3 scripts/claude-chains.py --summary-only
+    python3 scripts/claude-chains.py --subcommands --summary-only
 """
 
 import argparse
@@ -27,11 +28,28 @@ CLAUDE_DIR = Path.home() / ".claude" / "projects"
 
 _BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
 
+# CLIs where subcommands carry workflow signal.
+# Value = number of words to keep (including the CLI name itself).
+# gh needs 3: `gh run watch`, `gh pr create`, `gh issue list`
+_SUBCOMMAND_DEPTH: dict[str, int] = {
+    "gh": 3,
+    "git": 2,
+    "uv": 2,
+    "docker": 2,
+    "just": 2,
+    "chezmoi": 2,
+    "systemctl": 2,
+    "kubectl": 2,
+    "cargo": 2,
+    "npm": 2,
+}
 
-def bash_label(command: str) -> str:
+
+def bash_label(command: str, subcommands: bool = False) -> str:
     if not command:
         return "_shell"
     words = command.split()
+    effective: list[str] = []
     for word in words:
         if word in _BASH_WRAPPERS:
             continue
@@ -39,19 +57,55 @@ def bash_label(command: str) -> str:
             continue
         if word.startswith("$") or word.startswith("{"):
             return "_shell"
-        return Path(word).name or "_shell"
-    return "_shell"
+        if word.startswith("#"):
+            return "_shell"
+        effective.append(Path(word).name if not effective else word)
+        if not effective:
+            continue
+        break
+    if not effective:
+        return "_shell"
+
+    cli = effective[0]
+    if not subcommands or cli not in _SUBCOMMAND_DEPTH:
+        return cli
+
+    # Collect up to depth words, stopping at flags
+    depth = _SUBCOMMAND_DEPTH[cli]
+    parts = [cli]
+    remaining = [w for w in words[words.index(command.split()[0]) + 1:] if w]
+    # Re-derive from original words after wrappers
+    raw_words = command.split()
+    idx = 0
+    # Skip wrappers/env-vars to find CLI position
+    for i, w in enumerate(raw_words):
+        if w in _BASH_WRAPPERS:
+            continue
+        if "=" in w and not w.startswith("-"):
+            continue
+        idx = i
+        break
+    for w in raw_words[idx + 1:]:
+        if len(parts) >= depth:
+            break
+        if w.startswith("-"):
+            break
+        if "=" in w and not w.startswith("-"):
+            break
+        parts.append(w)
+
+    return " ".join(parts)
 
 
-def extract_tool_label(block: dict) -> str:
+def extract_tool_label(block: dict, subcommands: bool = False) -> str:
     name = block.get("name", "")
     if name == "Bash":
         cmd = block.get("input", {}).get("command", "")
-        return bash_label(cmd)
+        return bash_label(cmd, subcommands)
     return name
 
 
-def parse_session(path: Path) -> dict | None:
+def parse_session(path: Path, subcommands: bool = False) -> dict | None:
     turns: list[dict] = []
     session_id = path.stem
 
@@ -77,9 +131,10 @@ def parse_session(path: Path) -> dict | None:
                     continue
 
                 tool_labels = [
-                    extract_tool_label(b)
+                    label
                     for b in content
                     if isinstance(b, dict) and b.get("type") == "tool_use"
+                    and (label := extract_tool_label(b, subcommands)) != "_shell"
                 ]
 
                 if not tool_labels:
@@ -322,6 +377,8 @@ def main() -> None:
                         help="Write GitHub-renderable Mermaid markdown to this path")
     parser.add_argument("--summary-only", action="store_true",
                         help="Print n-gram summary only (ignores --output/--html/--markdown)")
+    parser.add_argument("--subcommands", action="store_true",
+                        help="Expand Bash labels to include subcommands (e.g. 'git commit', 'gh run watch')")
     args = parser.parse_args()
 
     paths = discover_sessions(args.since, args.project)
@@ -331,7 +388,7 @@ def main() -> None:
 
     records = []
     for p in paths:
-        rec = parse_session(p)
+        rec = parse_session(p, subcommands=args.subcommands)
         if rec:
             records.append(rec)
 


### PR DESCRIPTION
## Summary

- **Codeburn install**: switch from git ref to release tarball URL (`v0.9.1-thompsonson.4`) — more reliable and reproducible across machines
- **`scripts/claude-chains.py`**: new standalone script that extracts ordered tool-call sequences from `~/.claude/projects/**/*.jsonl` and computes top-20 n-gram patterns across sessions
- **Output flags**: `--html`, `--markdown`, `--subcommands`, `--summary-only`, `--project`, `--since`
- **`output/` gitignored**: prevents generated chains JSONL/HTML/MD files from being accidentally committed
- **Telemetry strategy doc**: `docs/claude-telemetry-strategy.md` — explains why the telemetry pipeline exists, what it feeds (workflow-service pattern registry), and what done looks like

## Context

`claude-chains.py` is the analysis layer for the Claude Code telemetry pipeline. It works directly on the raw session JSONL files (no dependencies beyond Python stdlib) and produces tool-chain n-grams that will inform workflow registrations in `thompsonson/workflow-service`.

The OTel collector pipeline (live forward telemetry) follows in a separate PR.

## Test plan

- [ ] `python3 scripts/claude-chains.py --since 7 --summary-only` — runs without error, prints n-gram table
- [ ] `python3 scripts/claude-chains.py --since 7 --output /tmp/chains.jsonl` — produces valid JSONL
- [ ] `head -1 /tmp/chains.jsonl | python3 -m json.tool` — parses cleanly
- [ ] `python3 scripts/claude-chains.py --summary-only | grep -E "git|gh"` — git→gh pattern appears in top results
- [ ] `chezmoi apply --dry-run` — deploys cleanly