### PR TITLE
feat(otel): Claude Code telemetry pipeline — OTel collector → SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ bin/
 # But include chezmoi-managed bin directories
 !executable_*/bin/
 !dot_*/bin/
+
+output/

--- a/docs/claude-telemetry-strategy.md
+++ b/docs/claude-telemetry-strategy.md
@@ -1,0 +1,91 @@
+# Claude Code Telemetry — Why and What Good Looks Like
+
+## Purpose
+
+This telemetry pipeline serves two connected goals:
+
+**1. Personal development analytics**
+As the sole developer and CTO of Manta Technologies, understand where Claude Code time is actually spent — across Manta repos, AtomicGuard, and personal tooling. Weekly and monthly retros, not live dashboards.
+
+**2. Empirical input to workflow-service**
+Claude Code's tool chains are real-world evidence of recurring workflows. A session that consistently runs `git commit → gh pr create → gh run watch` is a workflow that exists in practice. The telemetry pipeline captures these patterns so they can be registered in `workflow-service` — grounding its intent registry in observed behaviour rather than guesswork.
+
+The connection: **Claude Code produces tool chains → telemetry captures them → analysis reveals patterns → patterns become registered workflows → workflow-service routes voice/agent inputs to those workflows → atomicguard validates execution.**
+
+---
+
+## What this is not
+
+- Not an enterprise observability system
+- Not real-time dashboards or alerting
+- Not a replacement for Anthropic Console billing data
+- Not multi-user or shared infrastructure
+
+This is a lightweight personal tool: one Docker container, one SQLite file, a few Python scripts.
+
+---
+
+## The pipeline
+
+```
+Claude Code (any machine)
+  │  CLAUDE_CODE_ENABLE_TELEMETRY=1
+  │  OTEL_EXPORTER_OTLP_ENDPOINT → pop-mini:4318
+  ▼
+otelcol-contrib (Docker, pop-mini)
+  │  file exporter → JSONL rotation
+  ▼
+ingest.py (systemd timer, every 5 min)
+  │  byte-offset tracking, idempotent
+  ▼
+claude.db → table: events          ← live OTel forward stream
+
+~/.claude/projects/**/*.jsonl      ← existing transcripts
+  │  backfill.py (one-shot, idempotent)
+  ▼
+claude.db → table: legacy_events   ← historical data (back to Jan 2026)
+
+claude-chains.py                   ← tool-sequence n-gram analysis (standalone)
+otel-stats                         ← SQL presets for retros
+```
+
+---
+
+## What good looks like
+
+### Personal analytics (done when...)
+- `otel-stats hours-per-week --since=2026-01-01` gives a reliable weekly active-time view across all projects
+- `otel-stats by-project` shows where effort is concentrated across Manta vs AtomicGuard vs tooling
+- Token totals per day are queryable — giving a cost-proxy without hitting the Anthropic Console
+
+### Workflow-service input (done when...)
+- `claude-chains.py --summary-only --since 30` reliably surfaces the top 20 tool n-grams
+- At least 3 recurring patterns are clearly identifiable (e.g. `git → gh pr create`, `Read → Edit → Bash`, `Agent → git → gh`)
+- Those patterns are written up as candidate workflow registrations in `workflow-service`
+- The connection between "observed in telemetry" and "registered in workflow-service" is documented in that repo
+
+### Ongoing health (done when...)
+- `otel-ingest.timer` runs reliably on pop-mini with no manual intervention
+- New machines can opt in by touching `~/.config/claude-telemetry/enabled`
+- `sysbak` covers `~/.local/share/otel/data/` so the SQLite store is backed up
+
+---
+
+## Key questions this should answer
+
+| Question | Source |
+|---|---|
+| How many hours per week am I using Claude Code? | `otel-stats hours-per-week` |
+| Which projects take the most time? | `otel-stats by-project` |
+| What are the most common tool sequences? | `claude-chains.py --summary-only` |
+| Which tools fail most often? | `otel-stats by-tool` + error analysis |
+| Which workflows recur enough to register? | n-gram analysis → workflow-service |
+| How does usage split across Manta vs AtomicGuard? | `--project` filter on any preset |
+
+---
+
+## Related docs
+
+- [`claude-telemetry.md`](claude-telemetry.md) — ops reference: setup, activation, network, operations
+- [`claude-session-analysis.md`](claude-session-analysis.md) — historical analysis (Apr 2026 baseline)
+- [`workflow-service`](https://github.com/thompsonson/workflow-service) — the downstream consumer of workflow patterns

--- a/docs/claude-telemetry.md
+++ b/docs/claude-telemetry.md
@@ -1,179 +1,142 @@
-# Claude Code Telemetry & Multi-Machine Aggregation — Plan
+# Claude Code Telemetry — Pop-mini OTel Pipeline
 
-Notes from an exploration of how to track Claude Code cost / tokens / tool
-usage across machines, and how that interacts with [codeburn][cb].
+Central OTel collector on pop-mini, SQLite store, ingest from any machine
+running Claude Code. Codeburn-based retros are superseded by SQL against the
+ingested store.
 
-[cb]: https://github.com/thompsonson/codeburn
+## TL;DR
 
-## TL;DR — do this in order
+- **Where:** pop-mini hosts everything. Other machines push telemetry to it via
+  Tailscale MagicDNS (`pop-mini.monkey-ladon.ts.net:4318`).
+- **Stack:** `otelcol-contrib` in Docker → JSONL file exporter → Python
+  ingester on a systemd-user timer → SQLite at
+  `~/.local/share/otel/data/claude.db`.
+- **Backfill:** one-shot import of `~/.claude/projects/*/*.jsonl` and
+  `*/subagents/*.jsonl` into a separate `legacy_events` table for historical
+  retros. Goes back to Jan 2026 via subagent residuals.
+- **Retention:** sysbak already covers `~/.claude/projects/`. The SQLite store
+  also lives there once sysbak's include list picks up
+  `~/.local/share/otel/data/`.
+- **Goal:** retrospective analysis (weekly / monthly / project). Not live
+  dashboards.
 
-1. **Run the diagnostic in §1** before building anything. It answers whether
-   "only ~1 month showing in codeburn" is data loss or display windowing —
-   the answer changes what's worth doing next.
-2. **Add `~/.claude/projects/` to `sysbak`** (§2). Solves retention
-   independently of any tooling choice.
-3. **Decide on aggregation** (§3) only if step 1 confirms multiple machines
-   each hold sessions worth merging.
-4. **OTel telemetry env vars** (§4) are optional and orthogonal — only
-   useful if you'll actually look at dashboards.
+## Why this and not codeburn
 
----
+Codeburn reads top-level Claude transcripts; Claude Code auto-deletes those
+after `cleanupPeriodDays` (default 30). Sub-agent jsonls survive in nested
+dirs that the cleanup sweep doesn't reach. Codeburn ignores them, so its view
+is permanently windowed and silently incomplete. OTel captures forward-going
+data into a store we own, and the backfill rescues what's still on disk.
 
-## 1. Diagnostic — what's actually on disk?
+The Anthropic OTel surface (`CLAUDE_CODE_ENABLE_TELEMETRY=1`) is the
+officially supported channel; the local `.jsonl` files are documented as an
+internal "mirror destination" with no stable schema. See
+[Anthropic monitoring docs](https://code.claude.com/docs/en/monitoring-usage).
 
-Claude Code stores session transcripts as JSONL at
-`~/.claude/projects/<encoded-cwd>/<session-uuid>.jsonl`. There's no evidence
-Claude rotates them, so files going back >1 month should be present unless
-something else removed them.
+## Components
 
-Run on your laptop:
+| Path | Purpose |
+|---|---|
+| `~/.local/share/otel/config.yaml` | Collector config (OTLP HTTP/gRPC in, file exporter out) |
+| `~/.local/share/otel/compose.yml` | Docker compose (pop-mini only, `network_mode: host`) |
+| `~/.local/share/otel/schema.sql`  | SQLite schema — `events`, `legacy_events`, `ingest_state` |
+| `~/.local/share/otel/ingest.py`   | OTel JSONL → SQLite `events` (every 5 min via systemd timer) |
+| `~/.local/share/otel/backfill.py` | `~/.claude/projects/**/*.jsonl` → `legacy_events` (one-shot, idempotent) |
+| `~/.local/bin/otel-stats`         | Thin SQL wrapper with retro presets |
+| `~/.config/systemd/user/otel-ingest.{service,timer}` | Ingester runs every 5 min |
+| `run_once_after_install-otel-collector.sh.tmpl` (chezmoi) | First-time install, pop-mini-gated |
 
-```bash
-#!/usr/bin/env bash
-# Inventory ~/.claude session storage.
-# Distinguishes "data is gone" from "codeburn is windowing the display".
+## Activation
 
-set -u
-DIR="${CLAUDE_DIR:-$HOME/.claude/projects}"
-
-if [ ! -d "$DIR" ]; then
-  echo "No $DIR — Claude Code not installed or session dir is elsewhere."
-  exit 1
-fi
-
-echo "=== Inventory: $DIR ==="
-files=$(find "$DIR" -name '*.jsonl' 2>/dev/null | wc -l | tr -d ' ')
-projects=$(find "$DIR" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
-echo "$files session files across $projects project dirs"
-du -sh "$DIR" 2>/dev/null
-
-echo
-echo "=== Sessions older than... (by mtime) ==="
-for d in 30 60 90 180 365 730; do
-  n=$(find "$DIR" -name '*.jsonl' -mtime +$d 2>/dev/null | wc -l | tr -d ' ')
-  printf "  %4d days: %5s files\n" "$d" "$n"
-done
-
-echo
-echo "=== Newest / oldest by mtime ==="
-find "$DIR" -name '*.jsonl' 2>/dev/null -print0 \
-  | xargs -0 ls -lt 2>/dev/null \
-  | awk 'NR==1 {newest=$0} {oldest=$0} END {print "newest:", newest; print "oldest:", oldest}'
-
-echo
-echo "=== Largest projects ==="
-du -sh "$DIR"/*/ 2>/dev/null | sort -h | tail -10
-```
-
-### How to read the output
-
-| What you see | What it means | Next step |
-|---|---|---|
-| Files >30d old exist, codeburn UI shows ~1 month | codeburn is windowing the display | Check codeburn flags / config for the lookback window |
-| Few/no files >30d old, total size small | Data was removed (reinstall, cleanup, migration) | Restore from backup if you have one; treat retention as a backup problem from now on (§2) |
-| Lots of files but only one or two project dirs | You changed `cwd`s a lot or only used one project — probably fine | — |
-
-mtime is a first approximation: if you've copied files between machines it
-can lie. For a deeper check, the JSONL files contain per-event timestamps
-inside — parseable with `jq` if needed.
-
----
-
-## 2. Backup retention — do this regardless
-
-Whatever aggregation choice you make, the retention story should not depend
-on it. Add `~/.claude/projects/` (and `~/.claude/sessions/` if you care about
-metadata) to `sysbak`'s include list so the USB rsnapshot rotation owns
-historical session data.
-
-Once that's in place, "how far back can I see?" becomes "however far back
-your backup chain goes," not a tooling concern.
-
----
-
-## 3. Cross-machine aggregation
-
-Only worth building if you actually run Claude on multiple machines and
-want one combined view. If `pop-mini` is the only Claude host, skip this
-and just `ssh pop-mini codeburn` from elsewhere.
-
-### Recommended shape: sync-to-laptop, pull model
-
-- **Laptop is the aggregator.** Runs codeburn against a tree containing
-  its own sessions plus copies pulled from each remote host.
-- **Pull, not push.** A launchd timer on the laptop rsyncs from each
-  device over Tailscale/SSH on a schedule (e.g. every 15 min). Pull
-  handles "remote was offline" gracefully — next tick catches up. Push
-  from remotes has to deal with "laptop closed" and needs retry logic.
-- **Namespace per host, do not merge.** Pull into
-  `~/.claude-aggregated/<hostname>/projects/`, never into
-  `~/.claude/projects/`. Reasons:
-    - Keeps your live Claude Code untouched (no chance of seeing foreign
-      sessions in the running client).
-    - Gives you a free `(machine_id, session_id)` key via the directory
-      name — handles dedup if you ever ssh into another host and run
-      Claude there.
-    - Easy to wipe and re-sync if anything goes wrong.
-- **codeburn must support multiple roots.** Verify before designing the
-  rest. If it only reads `~/.claude/projects/`, either (a) PR a
-  `--scan-root` / env var, or (b) symlink children of the aggregated
-  tree under a single shadow root.
-
-### Why not "pop-mini as a server"
-
-codeburn today is a *parser* (reads provider session files from disk),
-not a *receiver*. Turning it into a server/client app means designing:
-an ingest API, schema versioning, auth tokens, retry/backoff on the
-client, dedup keys, a fan-out for new providers. That's weeks of work.
-
-Sync-to-laptop reuses 100% of the existing parser and is days of work
-(launchd plist + rsync wrapper + multi-root scan). You can graduate to
-real client/server later if file-sync hits a wall — e.g. you want
-sub-minute freshness or non-Unix clients.
-
-### Open questions to nail down before any code
-
-- **Menubar offline behaviour** — when the laptop is off-network, does
-  the menubar show stale-cached data, blank, or fall back to a local
-  parse? Decide now; affects how the read path is structured.
-- **Cursor SQLite** — codeburn parses Cursor's SQLite DB. Syncing a live
-  SQLite file is fine with WAL mode + rsync, but worth a sanity check
-  that the parser tolerates a snapshot taken mid-write.
-
----
-
-## 4. (Optional) OTel telemetry env vars
-
-Orthogonal to all of the above. Useful if you want *live* metrics (cost,
-tokens by model, tool success/failure, lines-of-code, commits, PRs) flowing
-to a dashboard rather than reconstructed from JSONL after the fact.
+After `chezmoi apply` on pop-mini:
 
 ```bash
-# In ~/.zshrc, ideally guarded by a per-machine opt-in toggle:
-if [ -f "$HOME/.config/claude-telemetry/enabled" ]; then
-  export CLAUDE_CODE_ENABLE_TELEMETRY=1
-  export OTEL_METRICS_EXPORTER=otlp
-  export OTEL_LOGS_EXPORTER=otlp
-  export OTEL_EXPORTER_OTLP_PROTOCOL=grpc
-  export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
-fi
+docker compose -f ~/.local/share/otel/compose.yml up -d   # if not already running
+python3 ~/.local/share/otel/backfill.py                   # first-time backfill
+systemctl --user enable --now otel-ingest.timer
+
+otel-stats hours-per-week --since=2026-04-01
+otel-stats by-project --since=2026-04-01
+otel-stats sql "SELECT model, COUNT(*) FROM legacy_events GROUP BY model;"
 ```
 
-The receiver options, lightest first:
+On a non-pop-mini machine:
 
-- `OTEL_METRICS_EXPORTER=console` — prints to terminal. Good for sanity
-  checks, useless for trends.
-- **Custom OTel→SQLite bridge** — ~100 lines of Python listening on
-  `:4317`, inserting into one file. Fits the dotfiles ethos; you own
-  the schema and retention.
-- **Anthropic's `claude-code-monitoring-guide` Docker stack** —
-  Prometheus + Loki + Grafana with pre-built dashboards. Heaviest
-  option; only worth it if you'll genuinely watch dashboards.
+```bash
+mkdir -p ~/.config/claude-telemetry && touch ~/.config/claude-telemetry/enabled
+exec zsh -l   # pick up env vars
+```
 
-Defaults to leave alone unless you have a reason: `OTEL_LOG_TOOL_DETAILS`
-(off — fattens logs fast), `OTEL_LOG_USER_PROMPTS` (off — privacy / size),
-`OTEL_LOG_RAW_API_BODIES` (off — size).
+## Network
 
-Note: Claude Code already has `/cost` for session-level spend with zero
-setup, and the Anthropic Console is the source of truth for billing. If
-cost is the only thing you care about, those two cover it.
+The collector uses `network_mode: host` so it listens on every interface — 127.0.0.1 for
+the local Claude shell, the LAN IP for in-house machines, the Tailscale IP for remote
+hosts. If you want to lock down:
+
+```bash
+sudo ufw allow in on tailscale0 to any port 4318 proto tcp
+sudo ufw allow in on tailscale0 to any port 4317 proto tcp
+sudo ufw deny  in to any port 4318 proto tcp
+sudo ufw deny  in to any port 4317 proto tcp
+```
+
+## Schema overview
+
+`legacy_events` (historical, codeburn-shaped):
+- `source_kind`: `session` or `subagent`
+- `ts, session_id, parent_session_id, project, git_branch, model`
+- `event_type, tool_name, tool_use_id, message_id`
+- `input_tokens, output_tokens, cache_read_tokens, cache_write_tokens`
+- `raw` (full JSON for inspection)
+
+`events` (forward OTel data):
+- `source`: `metrics`, `logs`, `traces`
+- `ts, service_name, host_name, scope_name, name, value, unit`
+- `trace_id, span_id`
+- `attributes, resource` (JSON)
+
+## Operations
+
+```bash
+# Status
+docker compose -f ~/.local/share/otel/compose.yml ps
+systemctl --user status otel-ingest.timer
+
+# Logs
+docker compose -f ~/.local/share/otel/compose.yml logs -f otelcol
+journalctl --user -u otel-ingest.service -f
+
+# Re-backfill (idempotent, picks up new files)
+python3 ~/.local/share/otel/backfill.py --verbose
+
+# Reset state (re-ingest everything next run)
+sqlite3 ~/.local/share/otel/data/claude.db "DELETE FROM ingest_state;"
+
+# Wipe (nuclear)
+docker compose -f ~/.local/share/otel/compose.yml down
+rm -rf ~/.local/share/otel/data
+```
+
+## What we considered
+
+- **Sync `~/.claude/projects/` to a single host with rsync** — viable but
+  clunky, and inherits codeburn's blind spot (subagent jsonls don't have token
+  data attached the way main sessions do, so reconstructed costs drift).
+- **MQTT bus** (chops broker on `:1884` is already running on pop-mini) — would
+  unify telemetry with the chops/atomicguard event stream but couples this
+  pipeline to a system that's not yet stable. Deferred; revisit when
+  workflow-service has shipped and there's a real holistic story.
+- **lestash co-location** — single SQLite for everything personal. Rejected
+  for now: telemetry and knowledge data have different query shapes and
+  different retention/privacy concerns.
+- **Prometheus + Loki + Grafana** (the official Anthropic monitoring stack) —
+  pure dashboard play, doesn't serve retro analysis. Out of scope.
+
+## Backup retention
+
+`~/.claude/projects/` is already in `sysbak`'s include list. Add
+`~/.local/share/otel/data/` for the SQLite + JSONL files to be backed up too:
+
+```bash
+sysbak config  # then add ~/.local/share/otel/data to includes
+```

--- a/dot_config/systemd/user/otel-ingest.service
+++ b/dot_config/systemd/user/otel-ingest.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Ingest OTel collector JSONL into Claude telemetry SQLite
+Documentation=file://%h/.local/share/otel/schema.sql
+After=default.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/env python3 %h/.local/share/otel/ingest.py
+Nice=10
+IOSchedulingClass=idle
+
+[Install]
+WantedBy=default.target

--- a/dot_config/systemd/user/otel-ingest.timer
+++ b/dot_config/systemd/user/otel-ingest.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run OTel JSONL→SQLite ingester every 5 min
+Documentation=file://%h/.local/share/otel/ingest.py
+
+[Timer]
+OnBootSec=2min
+OnUnitActiveSec=5min
+AccuracySec=30s
+Persistent=true
+Unit=otel-ingest.service
+
+[Install]
+WantedBy=timers.target

--- a/dot_local/bin/executable_otel-stats
+++ b/dot_local/bin/executable_otel-stats
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# otel-stats — thin SQL wrapper over ~/.local/share/otel/data/claude.db
+# Presets for retro analysis. Escape hatch: `otel-stats sql "<query>"`.
+#
+# Quantity = 5-min bucket method: count distinct (date, hour, slot) tuples
+# from legacy_events.ts and multiply by 5 to get minutes.
+
+set -euo pipefail
+
+DB="${OTEL_DB:-$HOME/.local/share/otel/data/claude.db}"
+
+if [ ! -f "$DB" ]; then
+  echo "no $DB — run backfill.py first" >&2
+  exit 1
+fi
+
+cmd="${1:-help}"; shift || true
+
+# Optional filters via env-var-style args: PROJECT=foo SINCE=2026-04-01
+PROJECT="${PROJECT:-}"
+SINCE="${SINCE:-1970-01-01}"
+UNTIL="${UNTIL:-9999-12-31}"
+for arg in "$@"; do
+  case "$arg" in
+    --project=*) PROJECT="${arg#--project=}" ;;
+    --since=*)   SINCE="${arg#--since=}" ;;
+    --until=*)   UNTIL="${arg#--until=}" ;;
+  esac
+done
+
+PROJ_FILTER=""
+if [ -n "$PROJECT" ]; then
+  # Strip characters that could break the SQL literal (local tool, but good practice).
+  PROJECT="${PROJECT//[^a-zA-Z0-9._-]/}"
+  PROJ_FILTER="AND project LIKE '%${PROJECT}%'"
+fi
+
+run() { sqlite3 -header -column "$DB" "$@"; }
+
+case "$cmd" in
+  help|-h|--help)
+    cat <<EOF
+otel-stats — Claude Code telemetry queries
+
+Usage:
+  otel-stats <preset> [--project=NAME] [--since=YYYY-MM-DD] [--until=YYYY-MM-DD]
+
+Presets:
+  hours-per-day     Active hours per calendar day
+  hours-per-week    Active hours per ISO week
+  hours-per-month   Active hours per month
+  by-project        Active hours grouped by project
+  by-tool           Tool-call counts grouped by tool name
+  by-model          Event counts grouped by model
+  sessions          Distinct session count per day
+  tokens            Token totals (input/output/cache) per day
+  recent            Last 50 events (raw)
+  schema            Show table + view definitions
+  sql "<query>"     Run an arbitrary SQL query
+
+Environment:
+  OTEL_DB           Override the database path (default: ~/.local/share/otel/data/claude.db)
+EOF
+    ;;
+
+  hours-per-day)
+    run "SELECT day, ROUND(SUM(minutes)/60.0, 2) AS hours
+         FROM (
+           SELECT date(ts) AS day,
+                  COUNT(DISTINCT substr(ts,12,2) || '|' ||
+                                 (cast(substr(ts,15,2) AS INTEGER)/5)) * 5 AS minutes
+           FROM legacy_events
+           WHERE date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+           GROUP BY date(ts)
+         )
+         GROUP BY day
+         ORDER BY day;"
+    ;;
+
+  hours-per-week)
+    run "SELECT strftime('%Y-W%W', ts) AS week,
+                ROUND(COUNT(DISTINCT date(ts) || '|' || substr(ts,12,2) || '|' ||
+                            (cast(substr(ts,15,2) AS INTEGER)/5)) * 5 / 60.0, 2) AS hours
+         FROM legacy_events
+         WHERE date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY week
+         ORDER BY week;"
+    ;;
+
+  hours-per-month)
+    run "SELECT strftime('%Y-%m', ts) AS month,
+                ROUND(COUNT(DISTINCT date(ts) || '|' || substr(ts,12,2) || '|' ||
+                            (cast(substr(ts,15,2) AS INTEGER)/5)) * 5 / 60.0, 2) AS hours
+         FROM legacy_events
+         WHERE date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY month
+         ORDER BY month;"
+    ;;
+
+  by-project)
+    run "SELECT project,
+                COUNT(*) AS events,
+                ROUND(COUNT(DISTINCT date(ts) || '|' || substr(ts,12,2) || '|' ||
+                            (cast(substr(ts,15,2) AS INTEGER)/5)) * 5 / 60.0, 2) AS hours
+         FROM legacy_events
+         WHERE date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY project
+         ORDER BY hours DESC;"
+    ;;
+
+  by-tool)
+    run "SELECT tool_name, COUNT(*) AS calls
+         FROM legacy_events
+         WHERE tool_name IS NOT NULL
+           AND date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY tool_name
+         ORDER BY calls DESC;"
+    ;;
+
+  by-model)
+    run "SELECT model, COUNT(*) AS events
+         FROM legacy_events
+         WHERE model IS NOT NULL
+           AND date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY model
+         ORDER BY events DESC;"
+    ;;
+
+  sessions)
+    run "SELECT date(ts) AS day, COUNT(DISTINCT session_id) AS sessions
+         FROM legacy_events
+         WHERE session_id IS NOT NULL
+           AND date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY day
+         ORDER BY day;"
+    ;;
+
+  tokens)
+    run "SELECT date(ts) AS day,
+                SUM(COALESCE(input_tokens,0))       AS input_tok,
+                SUM(COALESCE(output_tokens,0))      AS output_tok,
+                SUM(COALESCE(cache_read_tokens,0))  AS cache_read,
+                SUM(COALESCE(cache_write_tokens,0)) AS cache_write
+         FROM legacy_events
+         WHERE date(ts) BETWEEN '$SINCE' AND '$UNTIL' $PROJ_FILTER
+         GROUP BY day
+         HAVING input_tok > 0 OR output_tok > 0
+         ORDER BY day;"
+    ;;
+
+  recent)
+    run "SELECT ts, project, event_type, tool_name, model
+         FROM legacy_events
+         ORDER BY ts DESC
+         LIMIT 50;"
+    ;;
+
+  schema)
+    run "SELECT type, name, sql FROM sqlite_master
+         WHERE type IN ('table','view','index')
+           AND name NOT LIKE 'sqlite_%'
+         ORDER BY type, name;"
+    ;;
+
+  sql)
+    query="${1:-}"
+    [ -z "$query" ] && { echo "usage: otel-stats sql '<query>'" >&2; exit 2; }
+    run "$query"
+    ;;
+
+  *)
+    echo "unknown preset: $cmd (try 'otel-stats help')" >&2
+    exit 2
+    ;;
+esac

--- a/dot_local/share/otel/backfill.py
+++ b/dot_local/share/otel/backfill.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Backfill ~/.claude/projects/ JSONL transcripts into SQLite legacy_events.
+
+Sources, both walked recursively:
+  ~/.claude/projects/<project>/*.jsonl                      (top-level sessions)
+  ~/.claude/projects/<project>/<uuid>/subagents/*.jsonl     (sub-agent traces)
+
+Idempotent via ingest_state byte-offset tracking. Safe to re-run; updates rows
+appended to growing files. Re-parses fully if a file's inode changes (rotation).
+
+Run: python3 backfill.py [--verbose]
+"""
+from __future__ import annotations
+import json
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+CLAUDE_DIR  = Path(os.environ.get("CLAUDE_DIR", str(Path.home() / ".claude/projects")))
+DATA_DIR    = Path(os.environ.get("OTEL_DATA_DIR", str(Path.home() / ".local/share/otel/data")))
+DB_PATH     = DATA_DIR / "claude.db"
+SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+VERBOSE     = "--verbose" in sys.argv
+
+# Project slug → strip the encoded home-dir prefix from the Claude project dir name
+# to leave the meaningful part (e.g. `manta-manta-deploy`).
+# Derived from Path.home() so it works on any machine/username.
+PROJECT_PREFIX = re.sub(r"[/._]", "-", str(Path.home()))
+
+
+def connect() -> sqlite3.Connection:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    if SCHEMA_PATH.exists():
+        conn.executescript(SCHEMA_PATH.read_text())
+    return conn
+
+
+def project_slug(project_dir: Path) -> str:
+    name = project_dir.name
+    if name.startswith(PROJECT_PREFIX):
+        name = name[len(PROJECT_PREFIX):]
+    return name
+
+
+def parent_session_from_path(path: Path) -> str | None:
+    # subagent path: .../<project>/<session_uuid>/subagents/agent-<id>.jsonl
+    if path.parent.name == "subagents":
+        return path.parent.parent.name
+    return None
+
+
+def get_state(conn, key: str) -> tuple[int, int | None]:
+    row = conn.execute(
+        "SELECT byte_offset, inode FROM ingest_state WHERE source_file=?", (key,)
+    ).fetchone()
+    return (row[0], row[1]) if row else (0, None)
+
+
+def save_state(conn, key: str, offset: int, inode: int) -> None:
+    conn.execute(
+        """INSERT INTO ingest_state(source_file, byte_offset, inode, last_run)
+           VALUES(?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+           ON CONFLICT(source_file) DO UPDATE SET
+             byte_offset=excluded.byte_offset,
+             inode=excluded.inode,
+             last_run=excluded.last_run""",
+        (key, offset, inode),
+    )
+
+
+def extract_event(record: dict) -> dict:
+    """Pull the fields we want from a Claude jsonl record.
+
+    Claude records vary by type: 'user', 'assistant', 'tool_use', 'tool_result',
+    'summary', 'system', etc. We normalize what's present and store the raw JSON.
+    """
+    out = {
+        "ts": record.get("timestamp"),
+        "session_id": record.get("sessionId") or record.get("session_id"),
+        "git_branch": record.get("gitBranch") or record.get("git_branch"),
+        "model": None,
+        "event_type": record.get("type") or record.get("event_type"),
+        "message_id": None,
+        "tool_use_id": None,
+        "tool_name": record.get("toolName") or record.get("tool_name"),
+        "input_tokens": None,
+        "output_tokens": None,
+        "cache_read_tokens": None,
+        "cache_write_tokens": None,
+    }
+
+    # Some records nest message: {id, role, model, usage, content}
+    msg = record.get("message") or {}
+    if isinstance(msg, dict):
+        out["message_id"] = msg.get("id") or out["message_id"]
+        out["model"]      = msg.get("model") or out["model"]
+        usage = msg.get("usage") or {}
+        out["input_tokens"]       = usage.get("input_tokens")
+        out["output_tokens"]      = usage.get("output_tokens")
+        out["cache_read_tokens"]  = usage.get("cache_read_input_tokens")
+        out["cache_write_tokens"] = usage.get("cache_creation_input_tokens")
+        # Tool use lives in content as a block with type='tool_use'
+        content = msg.get("content")
+        if isinstance(content, list):
+            for block in content:
+                if isinstance(block, dict):
+                    if block.get("type") == "tool_use":
+                        out["tool_use_id"] = block.get("id") or out["tool_use_id"]
+                        out["tool_name"]   = block.get("name") or out["tool_name"]
+
+    # Top-level fallbacks (codeburn-export format uses these)
+    out["model"]       = record.get("model") or out["model"]
+    out["message_id"]  = record.get("message_id") or out["message_id"]
+    out["tool_use_id"] = record.get("tool_use_id") or out["tool_use_id"]
+
+    return out
+
+
+def ingest_jsonl(conn, path: Path, project: str, kind: str) -> int:
+    key = str(path)
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return 0
+    offset, prev_inode = get_state(conn, key)
+    if prev_inode is not None and prev_inode != st.st_ino:
+        offset = 0
+    if offset >= st.st_size:
+        return 0
+    parent = parent_session_from_path(path) if kind == "subagent" else None
+    claude_parent = str(CLAUDE_DIR.parent)
+    rel_path = str(path)[len(claude_parent):].lstrip("/") if str(path).startswith(claude_parent) else str(path)
+
+    inserted, batch = 0, []
+    with path.open("rb") as f:
+        f.seek(offset)
+        for raw in f:
+            try:
+                line = raw.decode("utf-8").strip()
+                if not line:
+                    continue
+                rec = json.loads(line)
+                e = extract_event(rec)
+                ts = e["ts"]
+                if not ts:
+                    continue
+                batch.append((
+                    rel_path, kind, ts,
+                    e["session_id"], parent, project, e["git_branch"], e["model"],
+                    e["event_type"], e["message_id"], e["tool_use_id"], e["tool_name"],
+                    e["input_tokens"], e["output_tokens"],
+                    e["cache_read_tokens"], e["cache_write_tokens"],
+                    line,
+                ))
+                if len(batch) >= 1000:
+                    conn.executemany(
+                        """INSERT INTO legacy_events(
+                             source_file, source_kind, ts,
+                             session_id, parent_session_id, project, git_branch, model,
+                             event_type, message_id, tool_use_id, tool_name,
+                             input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                             raw)
+                           VALUES(?,?,?, ?,?,?,?,?, ?,?,?,?, ?,?,?,?, ?)""",
+                        batch,
+                    )
+                    inserted += len(batch); batch.clear()
+            except json.JSONDecodeError:
+                continue
+            except Exception as e:
+                if VERBOSE:
+                    print(f"  skip {path.name}: {e}", file=sys.stderr)
+                continue
+        new_offset = f.tell()
+    if batch:
+        conn.executemany(
+            """INSERT INTO legacy_events(
+                 source_file, source_kind, ts,
+                 session_id, parent_session_id, project, git_branch, model,
+                 event_type, message_id, tool_use_id, tool_name,
+                 input_tokens, output_tokens, cache_read_tokens, cache_write_tokens,
+                 raw)
+               VALUES(?,?,?, ?,?,?,?,?, ?,?,?,?, ?,?,?,?, ?)""",
+            batch,
+        )
+        inserted += len(batch)
+    save_state(conn, key, new_offset, st.st_ino)
+    conn.commit()
+    return inserted
+
+
+def walk(conn) -> dict:
+    """Walk CLAUDE_DIR and ingest all JSONLs."""
+    stats = {"projects": 0, "session_files": 0, "subagent_files": 0,
+             "session_rows": 0, "subagent_rows": 0}
+    if not CLAUDE_DIR.exists():
+        print(f"no {CLAUDE_DIR}", file=sys.stderr)
+        return stats
+    for project_dir in sorted(CLAUDE_DIR.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        stats["projects"] += 1
+        proj = project_slug(project_dir)
+        for f in sorted(project_dir.glob("*.jsonl")):
+            n = ingest_jsonl(conn, f, proj, "session")
+            stats["session_files"] += 1
+            stats["session_rows"] += n
+            if VERBOSE and n:
+                print(f"  session {f.name}: {n}")
+        for f in sorted(project_dir.glob("*/subagents/*.jsonl")):
+            n = ingest_jsonl(conn, f, proj, "subagent")
+            stats["subagent_files"] += 1
+            stats["subagent_rows"] += n
+            if VERBOSE and n:
+                print(f"  subagent {f.name}: {n}")
+    return stats
+
+
+def main() -> int:
+    conn = connect()
+    print(f"backfill from {CLAUDE_DIR} -> {DB_PATH}")
+    stats = walk(conn)
+    print(f"projects: {stats['projects']}")
+    print(f"session files: {stats['session_files']}  ({stats['session_rows']} rows)")
+    print(f"subagent files: {stats['subagent_files']} ({stats['subagent_rows']} rows)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dot_local/share/otel/compose.yml
+++ b/dot_local/share/otel/compose.yml
@@ -1,0 +1,25 @@
+# OTel collector for Claude Code telemetry. Pop-mini only.
+#
+# Bring up:   docker compose -f ~/.local/share/otel/compose.yml up -d
+# Tear down:  docker compose -f ~/.local/share/otel/compose.yml down
+# Logs:       docker compose -f ~/.local/share/otel/compose.yml logs -f otelcol
+#
+# Bind: 127.0.0.1 (local) + Tailscale IP. Optionally lock down with ufw:
+#   sudo ufw allow in on tailscale0 to any port 4318 proto tcp
+#   sudo ufw allow in on tailscale0 to any port 4317 proto tcp
+
+services:
+  otelcol:
+    image: otel/opentelemetry-collector-contrib:0.110.0
+    container_name: otelcol-claude
+    restart: unless-stopped
+    command: ["--config=/etc/otelcol/config.yaml"]
+    volumes:
+      - ${HOME}/.local/share/otel/config.yaml:/etc/otelcol/config.yaml:ro
+      - ${HOME}/.local/share/otel/data:/data
+    network_mode: host
+    healthcheck:
+      test: ["CMD", "wget", "-q", "-O-", "http://localhost:13133/"]
+      interval: 30s
+      timeout: 5s
+      retries: 3

--- a/dot_local/share/otel/config.yaml
+++ b/dot_local/share/otel/config.yaml
@@ -1,0 +1,52 @@
+# OpenTelemetry Collector config — Claude Code telemetry pipeline.
+# Runs on pop-mini only. Other machines push here via Tailscale MagicDNS.
+# Receivers: OTLP HTTP (4318) + gRPC (4317).
+# Exporters: file (JSONL with rotation) -> ingest.py reads into SQLite.
+
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: 0.0.0.0:4318
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+processors:
+  batch:
+    timeout: 5s
+    send_batch_size: 1024
+  resourcedetection:
+    detectors: [env, system]
+    timeout: 2s
+
+exporters:
+  file/metrics:
+    path: /data/metrics.jsonl
+    rotation: {max_megabytes: 50, max_days: 365, max_backups: 14}
+  file/logs:
+    path: /data/logs.jsonl
+    rotation: {max_megabytes: 50, max_days: 365, max_backups: 14}
+  file/traces:
+    path: /data/traces.jsonl
+    rotation: {max_megabytes: 50, max_days: 365, max_backups: 14}
+
+extensions:
+  health_check: {endpoint: 0.0.0.0:13133}
+
+service:
+  extensions: [health_check]
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [file/metrics]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [file/logs]
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection, batch]
+      exporters: [file/traces]
+  telemetry:
+    logs: {level: info}

--- a/dot_local/share/otel/ingest.py
+++ b/dot_local/share/otel/ingest.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Ingest OTel collector file-exporter JSONL into SQLite (forward stream).
+
+Idempotent via byte-offset tracking; handles rotation by detecting inode changes.
+Runs from systemd-user timer every 5 min.
+
+Inputs:  $HOME/.local/share/otel/data/{metrics,logs,traces}.jsonl[.N]
+Output:  $HOME/.local/share/otel/data/claude.db -> table `events`
+"""
+from __future__ import annotations
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+DATA_DIR    = Path(os.environ.get("OTEL_DATA_DIR", str(Path.home() / ".local/share/otel/data")))
+DB_PATH     = DATA_DIR / "claude.db"
+SCHEMA_PATH = Path(__file__).parent / "schema.sql"
+SOURCES     = ["metrics", "logs", "traces"]
+
+
+def connect() -> sqlite3.Connection:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(DB_PATH)
+    if SCHEMA_PATH.exists():
+        conn.executescript(SCHEMA_PATH.read_text())
+    return conn
+
+
+def find_files(source: str) -> list[Path]:
+    return sorted(DATA_DIR.glob(f"{source}.jsonl*"))
+
+
+def get_state(conn, path: Path) -> tuple[int, int | None]:
+    row = conn.execute(
+        "SELECT byte_offset, inode FROM ingest_state WHERE source_file=?",
+        (str(path),),
+    ).fetchone()
+    return (row[0], row[1]) if row else (0, None)
+
+
+def save_state(conn, path: Path, offset: int, inode: int) -> None:
+    conn.execute(
+        """INSERT INTO ingest_state(source_file, byte_offset, inode, last_run)
+           VALUES(?, ?, ?, strftime('%Y-%m-%dT%H:%M:%fZ','now'))
+           ON CONFLICT(source_file) DO UPDATE SET
+             byte_offset=excluded.byte_offset,
+             inode=excluded.inode,
+             last_run=excluded.last_run""",
+        (str(path), offset, inode),
+    )
+
+
+def _resource_attrs(resource: dict) -> tuple[str | None, str | None, str]:
+    attrs = {a["key"]: next(iter(a.get("value", {}).values()), None)
+             for a in resource.get("attributes", [])}
+    return attrs.get("service.name"), attrs.get("host.name"), json.dumps(attrs)
+
+
+def _flatten(attrs: list | None) -> str:
+    out = {}
+    for a in attrs or []:
+        v = a.get("value", {})
+        out[a["key"]] = next(iter(v.values()), None) if v else None
+    return json.dumps(out)
+
+
+def _ns_to_iso(ns) -> str:
+    if ns is None:
+        return ""
+    import datetime as _dt
+    return _dt.datetime.fromtimestamp(int(ns) / 1e9, tz=_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def parse_metrics(line: str) -> list[tuple]:
+    rows, obj = [], json.loads(line)
+    for rm in obj.get("resourceMetrics", []):
+        svc, host, res = _resource_attrs(rm.get("resource", {}))
+        for sm in rm.get("scopeMetrics", []):
+            scope = sm.get("scope", {}).get("name")
+            for m in sm.get("metrics", []):
+                name, unit = m.get("name"), m.get("unit")
+                points = (m.get("sum") or m.get("gauge") or m.get("histogram") or {}).get("dataPoints", [])
+                for p in points:
+                    ts  = _ns_to_iso(p.get("timeUnixNano"))
+                    val = p.get("asDouble") or p.get("asInt") or p.get("count")
+                    rows.append(("metrics", ts, svc, host, scope, name, val, unit,
+                                 None, None, _flatten(p.get("attributes")), res))
+    return rows
+
+
+def parse_logs(line: str) -> list[tuple]:
+    rows, obj = [], json.loads(line)
+    for rl in obj.get("resourceLogs", []):
+        svc, host, res = _resource_attrs(rl.get("resource", {}))
+        for sl in rl.get("scopeLogs", []):
+            scope = sl.get("scope", {}).get("name")
+            for r in sl.get("logRecords", []):
+                ts   = _ns_to_iso(r.get("timeUnixNano") or r.get("observedTimeUnixNano"))
+                name = r.get("severityText") or "log"
+                body = r.get("body", {})
+                body_val = next(iter(body.values()), None) if body else None
+                attrs = json.loads(_flatten(r.get("attributes")))
+                attrs["body"] = body_val
+                rows.append(("logs", ts, svc, host, scope, name, None, None,
+                             r.get("traceId"), r.get("spanId"), json.dumps(attrs), res))
+    return rows
+
+
+def parse_traces(line: str) -> list[tuple]:
+    rows, obj = [], json.loads(line)
+    for rs in obj.get("resourceSpans", []):
+        svc, host, res = _resource_attrs(rs.get("resource", {}))
+        for ss in rs.get("scopeSpans", []):
+            scope = ss.get("scope", {}).get("name")
+            for sp in ss.get("spans", []):
+                ts = _ns_to_iso(sp.get("startTimeUnixNano"))
+                rows.append(("traces", ts, svc, host, scope, sp.get("name"), None, None,
+                             sp.get("traceId"), sp.get("spanId"),
+                             _flatten(sp.get("attributes")), res))
+    return rows
+
+
+PARSERS = {"metrics": parse_metrics, "logs": parse_logs, "traces": parse_traces}
+
+
+def ingest_file(conn, source: str, path: Path) -> int:
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return 0
+    offset, prev_inode = get_state(conn, path)
+    if prev_inode is not None and prev_inode != st.st_ino:
+        offset = 0  # rotated
+    if offset >= st.st_size:
+        return 0
+    parser, inserted, batch = PARSERS[source], 0, []
+    with path.open("rb") as f:
+        f.seek(offset)
+        for raw in f:
+            try:
+                line = raw.decode("utf-8").strip()
+                if not line:
+                    continue
+                batch.extend(parser(line))
+                if len(batch) >= 1000:
+                    conn.executemany(
+                        "INSERT INTO events(source,ts,service_name,host_name,scope_name,name,value,unit,trace_id,span_id,attributes,resource) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+                        batch,
+                    )
+                    inserted += len(batch); batch.clear()
+            except Exception as e:
+                print(f"parse error {path.name}: {e}", file=sys.stderr)
+        new_offset = f.tell()
+    if batch:
+        conn.executemany(
+            "INSERT INTO events(source,ts,service_name,host_name,scope_name,name,value,unit,trace_id,span_id,attributes,resource) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)",
+            batch,
+        )
+        inserted += len(batch)
+    save_state(conn, path, new_offset, st.st_ino)
+    conn.commit()
+    return inserted
+
+
+def main() -> int:
+    conn = connect()
+    total = 0
+    for source in SOURCES:
+        for path in find_files(source):
+            n = ingest_file(conn, source, path)
+            if n:
+                print(f"ingested {n} rows from {path.name}")
+            total += n
+    if total or "--verbose" in sys.argv:
+        print(f"total ingested: {total}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dot_local/share/otel/schema.sql
+++ b/dot_local/share/otel/schema.sql
@@ -1,0 +1,99 @@
+-- Claude Code telemetry store.
+-- Two tables: `events` (live OTel data, written by ingest.py) and
+-- `legacy_events` (historical Claude transcripts, written by backfill.py).
+-- `ingest_state` tracks per-file byte offsets so ingest.py is idempotent.
+
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous  = NORMAL;
+
+-- ---------------------------------------------------------------------------
+-- Live OTel data (forward-going)
+-- One row per metric data point, log record, or span.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS events (
+  id           INTEGER PRIMARY KEY AUTOINCREMENT,
+  ingested_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  source       TEXT NOT NULL,           -- 'metrics' | 'logs' | 'traces'
+  ts           TEXT NOT NULL,           -- ISO 8601 event time
+  service_name TEXT,
+  host_name    TEXT,
+  scope_name   TEXT,
+  name         TEXT,
+  value        REAL,                    -- metrics only
+  unit         TEXT,
+  trace_id     TEXT,
+  span_id      TEXT,
+  attributes   TEXT,                    -- JSON
+  resource     TEXT                     -- JSON
+);
+CREATE INDEX IF NOT EXISTS idx_events_ts      ON events(ts);
+CREATE INDEX IF NOT EXISTS idx_events_name    ON events(name);
+CREATE INDEX IF NOT EXISTS idx_events_source  ON events(source);
+CREATE INDEX IF NOT EXISTS idx_events_service ON events(service_name);
+CREATE INDEX IF NOT EXISTS idx_events_host    ON events(host_name);
+
+-- ---------------------------------------------------------------------------
+-- Historical backfill from ~/.claude/projects (codeburn-shaped)
+-- Sources: top-level session jsonls + nested subagent jsonls.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS legacy_events (
+  id                  INTEGER PRIMARY KEY AUTOINCREMENT,
+  ingested_at         TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  source_file         TEXT NOT NULL,    -- jsonl path relative to ~/.claude/projects
+  source_kind         TEXT NOT NULL,    -- 'session' | 'subagent'
+  ts                  TEXT NOT NULL,    -- ISO 8601
+  session_id          TEXT,
+  parent_session_id   TEXT,             -- for subagent: enclosing session uuid
+  project             TEXT,             -- project slug from dir name
+  git_branch          TEXT,
+  model               TEXT,
+  event_type          TEXT,             -- 'user' | 'assistant' | 'tool_call' | 'tool_result' | ...
+  message_id          TEXT,
+  tool_use_id         TEXT,
+  tool_name           TEXT,
+  input_tokens        INTEGER,
+  output_tokens       INTEGER,
+  cache_read_tokens   INTEGER,
+  cache_write_tokens  INTEGER,
+  raw                 TEXT              -- original JSON line, for inspection
+);
+CREATE INDEX IF NOT EXISTS idx_legacy_ts       ON legacy_events(ts);
+CREATE INDEX IF NOT EXISTS idx_legacy_project  ON legacy_events(project);
+CREATE INDEX IF NOT EXISTS idx_legacy_session  ON legacy_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_legacy_kind     ON legacy_events(source_kind);
+CREATE INDEX IF NOT EXISTS idx_legacy_tool     ON legacy_events(tool_name);
+
+-- ---------------------------------------------------------------------------
+-- Ingest state — per-file byte offsets so ingest.py / backfill.py are idempotent.
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS ingest_state (
+  source_file  TEXT PRIMARY KEY,
+  byte_offset  INTEGER NOT NULL DEFAULT 0,
+  inode        INTEGER,
+  last_run     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+);
+
+-- ---------------------------------------------------------------------------
+-- Convenience views for retros.
+-- ---------------------------------------------------------------------------
+
+-- Unified timeline across both tables (for cross-period queries).
+CREATE VIEW IF NOT EXISTS all_events AS
+  SELECT ts, 'events' AS table_name, source_name AS event_source,
+         service_name AS project, name AS tool_name, NULL AS session_id, NULL AS model
+  FROM (SELECT ts, source AS source_name, service_name, name FROM events)
+  UNION ALL
+  SELECT ts, 'legacy_events' AS table_name, source_kind AS event_source,
+         project, tool_name, session_id, model
+  FROM legacy_events;
+
+-- Active-time per day via 5-min bucket method on legacy_events.
+-- (events table will need its own view once OTel data flows.)
+CREATE VIEW IF NOT EXISTS legacy_active_buckets AS
+  SELECT
+    date(ts)                              AS day,
+    substr(ts, 12, 2)                     AS hour,
+    cast(substr(ts, 15, 2) AS INTEGER)/5  AS slot,
+    project
+  FROM legacy_events
+  GROUP BY day, hour, slot, project;

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -258,5 +258,22 @@ _sysbak_completion() {
 }
 compdef _sysbak_completion sysbak 2>/dev/null
 
+# Claude Code OpenTelemetry export → pop-mini central collector.
+# pop-mini: always-on (it hosts the collector, see ~/.local/share/otel/).
+# Other machines: opt-in via `touch ~/.config/claude-telemetry/enabled`.
+if [[ "$HOST" == "pop-mini" ]]; then
+  export CLAUDE_CODE_ENABLE_TELEMETRY=1
+  export OTEL_METRICS_EXPORTER=otlp
+  export OTEL_LOGS_EXPORTER=otlp
+  export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://127.0.0.1:4318
+elif [ -f "$HOME/.config/claude-telemetry/enabled" ]; then
+  export CLAUDE_CODE_ENABLE_TELEMETRY=1
+  export OTEL_METRICS_EXPORTER=otlp
+  export OTEL_LOGS_EXPORTER=otlp
+  export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+  export OTEL_EXPORTER_OTLP_ENDPOINT=http://pop-mini.monkey-ladon.ts.net:4318
+fi
+
 # source the PowerLevel10k config
 [[ ! -f ~/.p10k.zsh ]] || source ~/.p10k.zsh

--- a/run_once_after_install-codeburn.sh
+++ b/run_once_after_install-codeburn.sh
@@ -10,5 +10,5 @@ if ! command -v npm >/dev/null 2>&1; then
 fi
 
 echo 'Installing codeburn from thompsonson/codeburn...'
-npm install -g thompsonson/codeburn#v0.9.1-thompsonson.3
+npm install -g https://github.com/thompsonson/codeburn/releases/download/v0.9.1-thompsonson.4/codeburn.tgz
 echo "codeburn installed: $(codeburn --version 2>/dev/null || echo 'unknown version')"

--- a/run_once_after_install-otel-collector.sh.tmpl
+++ b/run_once_after_install-otel-collector.sh.tmpl
@@ -1,0 +1,58 @@
+#!/bin/bash
+# Install the Claude Code OTel collector on pop-mini.
+# Other machines: opt-in via `mkdir -p ~/.config/claude-telemetry && touch ~/.config/claude-telemetry/enabled`
+# Runs once per machine; re-runs if this file changes.
+
+set -euo pipefail
+
+{{- if eq .chezmoi.hostname "pop-mini" }}
+
+echo '== Installing Claude Code OTel collector (pop-mini) =='
+
+# 1. Data dir
+mkdir -p "$HOME/.local/share/otel/data"
+
+# 2. Docker check
+if ! command -v docker >/dev/null 2>&1; then
+  echo 'docker not found — install docker first, then re-run `chezmoi apply`' >&2
+  exit 1
+fi
+
+# 3. Pull the collector image (idempotent)
+docker pull otel/opentelemetry-collector-contrib:0.110.0
+
+# 4. Bring up the collector
+docker compose -f "$HOME/.local/share/otel/compose.yml" up -d
+sleep 3
+docker compose -f "$HOME/.local/share/otel/compose.yml" ps
+
+# 5. Initial backfill of historical ~/.claude/projects (idempotent)
+echo '== Backfilling historical Claude transcripts =='
+python3 "$HOME/.local/share/otel/backfill.py"
+
+# 6. Enable + start the ingest timer
+systemctl --user daemon-reload
+systemctl --user enable --now otel-ingest.timer
+systemctl --user status --no-pager otel-ingest.timer | head -10
+
+cat <<EOF
+
+✓ OTel collector running on pop-mini (ports 4317/4318)
+✓ SQLite DB: ~/.local/share/otel/data/claude.db
+✓ Ingest timer active (every 5 min)
+
+Test:   otel-stats hours-per-week --since=2026-04-01
+Logs:   docker compose -f ~/.local/share/otel/compose.yml logs -f otelcol
+Status: systemctl --user status otel-ingest.timer
+EOF
+
+{{- else }}
+
+# Non-pop-mini machines: nothing to install. The zshrc env vars handle the
+# opt-in toggle. Touch ~/.config/claude-telemetry/enabled to start sending.
+echo 'OTel collector install skipped — this is not pop-mini.'
+echo 'To send telemetry to pop-mini from this machine:'
+echo '  mkdir -p ~/.config/claude-telemetry && touch ~/.config/claude-telemetry/enabled'
+echo '  (new shells will pick up the env vars)'
+
+{{- end }}

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -10,6 +10,8 @@ Usage:
     python3 scripts/claude-chains.py --since 30
     python3 scripts/claude-chains.py --project atomicguard --since 7
     python3 scripts/claude-chains.py --output /tmp/chains-7d.jsonl
+    python3 scripts/claude-chains.py --html /tmp/chains.html
+    python3 scripts/claude-chains.py --markdown /tmp/chains.md
     python3 scripts/claude-chains.py --summary-only
 """
 
@@ -18,35 +20,30 @@ import json
 import sys
 import time
 from collections import Counter
-from datetime import UTC, datetime, timedelta
+from datetime import datetime, timezone
 from pathlib import Path
 
 CLAUDE_DIR = Path.home() / ".claude" / "projects"
-OUTPUT_DIR = Path("output")
 
 _BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
 
 
 def bash_label(command: str) -> str:
-    """Return the effective command name from a Bash input.command string."""
     if not command:
         return "_shell"
     words = command.split()
     for word in words:
         if word in _BASH_WRAPPERS:
             continue
-        # Skip env VAR=value tokens
         if "=" in word and not word.startswith("-"):
             continue
         if word.startswith("$") or word.startswith("{"):
             return "_shell"
-        # Strip path prefix: /usr/bin/git -> git
         return Path(word).name or "_shell"
     return "_shell"
 
 
 def extract_tool_label(block: dict) -> str:
-    """Return a label for a tool_use block."""
     name = block.get("name", "")
     if name == "Bash":
         cmd = block.get("input", {}).get("command", "")
@@ -55,9 +52,8 @@ def extract_tool_label(block: dict) -> str:
 
 
 def parse_session(path: Path) -> dict | None:
-    """Parse a session JSONL file into a sequence record. Returns None on error."""
     turns: list[dict] = []
-    session_id = path.stem  # filename without .jsonl
+    session_id = path.stem
 
     try:
         with open(path) as f:
@@ -73,7 +69,6 @@ def parse_session(path: Path) -> dict | None:
                 if obj.get("type") != "assistant":
                     continue
 
-                # Timestamp is top-level on the record
                 ts = obj.get("timestamp", "")
                 uuid = obj.get("uuid", "")
                 content = obj.get("message", {}).get("content", [])
@@ -112,7 +107,6 @@ def parse_session(path: Path) -> dict | None:
 
 
 def discover_sessions(since_days: int, project: str | None) -> list[Path]:
-    """Return .jsonl session files modified within since_days, optionally filtered by project."""
     if not CLAUDE_DIR.exists():
         return []
 
@@ -135,18 +129,183 @@ def ngrams(stream: list[str], n: int) -> list[tuple[str, ...]]:
     return [tuple(stream[i : i + n]) for i in range(len(stream) - n + 1)]
 
 
-def summarise(records: list[dict], top_n: int = 20) -> None:
+def compute_ngrams(records: list[dict], top_n: int = 20) -> list[tuple[tuple, int]]:
     counts: Counter = Counter()
     for rec in records:
         flat = [t for turn in rec["sequence"] for t in turn["tools"]]
         for n in (2, 3, 4):
             counts.update(ngrams(flat, n))
+    return counts.most_common(top_n)
 
+
+def project_stats(records: list[dict]) -> list[tuple[str, int, int]]:
+    """Return (project_key, session_count, turn_count) sorted by sessions desc."""
+    by_project: dict[str, list[int]] = {}
+    for rec in records:
+        pk = rec["project_key"]
+        by_project.setdefault(pk, []).append(rec["turns"])
+    return sorted(
+        [(pk, len(turns), sum(turns)) for pk, turns in by_project.items()],
+        key=lambda x: x[1],
+        reverse=True,
+    )
+
+
+def summarise(records: list[dict], top_n: int = 20) -> None:
+    top = compute_ngrams(records, top_n)
     print(f"\nTop {top_n} tool n-grams (size 2–4) across {len(records)} sessions:\n")
     print(f"  {'Count':>6}  Pattern")
     print(f"  {'------':>6}  -------")
-    for pattern, count in counts.most_common(top_n):
+    for pattern, count in top:
         print(f"  {count:>6}  {' → '.join(pattern)}")
+
+
+def write_html(records: list[dict], path: Path, since_days: int) -> None:
+    top = compute_ngrams(records, 20)
+    stats = project_stats(records)
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    labels_js = json.dumps([" → ".join(p) for p, _ in top])
+    counts_js = json.dumps([c for _, c in top])
+    proj_labels_js = json.dumps([pk.replace("-home-mt-Projects-", "").replace("-home-mt-", "") for pk, _, _ in stats])
+    proj_sessions_js = json.dumps([s for _, s, _ in stats])
+    proj_turns_js = json.dumps([t for _, _, t in stats])
+
+    html = f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Claude Code Tool Chains</title>
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4/dist/chart.umd.min.js"></script>
+<style>
+  body {{ font-family: system-ui, sans-serif; background: #0d1117; color: #e6edf3; margin: 0; padding: 24px; }}
+  h1 {{ font-size: 1.4rem; margin-bottom: 4px; }}
+  .meta {{ color: #8b949e; font-size: 0.85rem; margin-bottom: 32px; }}
+  .grid {{ display: grid; grid-template-columns: 1fr 1fr; gap: 24px; }}
+  .card {{ background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 20px; }}
+  .card h2 {{ font-size: 1rem; margin: 0 0 16px; color: #e6edf3; }}
+  canvas {{ max-height: 420px; }}
+  table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; margin-top: 12px; }}
+  th {{ text-align: left; color: #8b949e; border-bottom: 1px solid #30363d; padding: 6px 8px; }}
+  td {{ padding: 5px 8px; border-bottom: 1px solid #21262d; }}
+  .num {{ text-align: right; font-variant-numeric: tabular-nums; }}
+</style>
+</head>
+<body>
+<h1>Claude Code Tool Chains</h1>
+<p class="meta">Last {since_days} days &middot; {len(records)} sessions &middot; generated {generated}</p>
+<div class="grid">
+  <div class="card" style="grid-column: 1 / -1;">
+    <h2>Top 20 Tool N-grams (size 2–4)</h2>
+    <canvas id="ngram"></canvas>
+  </div>
+  <div class="card">
+    <h2>Sessions by Project</h2>
+    <canvas id="proj"></canvas>
+  </div>
+  <div class="card">
+    <h2>N-gram Table</h2>
+    <table>
+      <tr><th>Pattern</th><th class="num">Count</th></tr>
+      {''.join(f'<tr><td>{" → ".join(p)}</td><td class="num">{c}</td></tr>' for p, c in top)}
+    </table>
+  </div>
+</div>
+<script>
+const ngLabels = {labels_js};
+const ngCounts = {counts_js};
+const projLabels = {proj_labels_js};
+const projSessions = {proj_sessions_js};
+const projTurns = {proj_turns_js};
+
+new Chart(document.getElementById('ngram'), {{
+  type: 'bar',
+  data: {{
+    labels: ngLabels,
+    datasets: [{{ label: 'Occurrences', data: ngCounts,
+      backgroundColor: 'rgba(88,166,255,0.7)', borderRadius: 4 }}]
+  }},
+  options: {{
+    indexAxis: 'y',
+    plugins: {{ legend: {{ display: false }} }},
+    scales: {{
+      x: {{ grid: {{ color: '#21262d' }}, ticks: {{ color: '#8b949e' }} }},
+      y: {{ grid: {{ display: false }}, ticks: {{ color: '#e6edf3', font: {{ family: 'monospace' }} }} }}
+    }}
+  }}
+}});
+
+new Chart(document.getElementById('proj'), {{
+  type: 'bar',
+  data: {{
+    labels: projLabels,
+    datasets: [
+      {{ label: 'Sessions', data: projSessions, backgroundColor: 'rgba(63,185,80,0.7)', borderRadius: 4 }},
+      {{ label: 'Turns', data: projTurns, backgroundColor: 'rgba(210,153,34,0.5)', borderRadius: 4 }}
+    ]
+  }},
+  options: {{
+    plugins: {{ legend: {{ labels: {{ color: '#8b949e' }} }} }},
+    scales: {{
+      x: {{ grid: {{ color: '#21262d' }}, ticks: {{ color: '#8b949e', font: {{ family: 'monospace', size: 11 }} }}, maxRotation: 45 }},
+      y: {{ grid: {{ color: '#21262d' }}, ticks: {{ color: '#8b949e' }} }}
+    }}
+  }}
+}});
+</script>
+</body>
+</html>"""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(html + "\n")
+    print(f"HTML:     {path}")
+
+
+def write_markdown(records: list[dict], path: Path, since_days: int) -> None:
+    top = compute_ngrams(records, 20)
+    stats = project_stats(records)
+    generated = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    # Mermaid xychart-beta supports up to ~10 bars cleanly
+    top10 = top[:10]
+    mermaid_labels = [f'"{" → ".join(p)}"' for p, _ in top10]
+    mermaid_counts = [str(c) for _, c in top10]
+
+    lines = [
+        "# Claude Code Tool Chains",
+        "",
+        f"_Last {since_days} days · {len(records)} sessions · generated {generated}_",
+        "",
+        "## Top 10 N-grams",
+        "",
+        "```mermaid",
+        "xychart-beta horizontal",
+        f'    x-axis [{", ".join(mermaid_labels)}]',
+        f'    bar [{", ".join(mermaid_counts)}]',
+        "```",
+        "",
+        "## Full Top 20 N-gram Table",
+        "",
+        "| Pattern | Count |",
+        "|---------|------:|",
+    ]
+    for pattern, count in top:
+        lines.append(f"| `{' → '.join(pattern)}` | {count} |")
+
+    lines += [
+        "",
+        "## Sessions by Project",
+        "",
+        "| Project | Sessions | Turns |",
+        "|---------|--------:|------:|",
+    ]
+    for pk, sessions, turns in stats:
+        short = pk.replace("-home-mt-Projects-", "").replace("-home-mt-", "")
+        lines.append(f"| `{short}` | {sessions} | {turns} |")
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(lines) + "\n")
+    print(f"Markdown: {path}")
 
 
 def main() -> None:
@@ -157,8 +316,12 @@ def main() -> None:
                         help="Filter by substring of encoded project dir name")
     parser.add_argument("--output", metavar="FILE",
                         help="Write per-session JSONL to this path")
+    parser.add_argument("--html", metavar="FILE",
+                        help="Write self-contained HTML visualisation to this path")
+    parser.add_argument("--markdown", metavar="FILE",
+                        help="Write GitHub-renderable Mermaid markdown to this path")
     parser.add_argument("--summary-only", action="store_true",
-                        help="Print n-gram summary only (ignores --output)")
+                        help="Print n-gram summary only (ignores --output/--html/--markdown)")
     args = parser.parse_args()
 
     paths = discover_sessions(args.since, args.project)
@@ -176,13 +339,18 @@ def main() -> None:
         print("No tool-call sequences found in selected sessions.", file=sys.stderr)
         sys.exit(1)
 
-    if not args.summary_only and args.output:
-        out_path = Path(args.output)
-        out_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(out_path, "w") as f:
-            for rec in records:
-                f.write(json.dumps(rec) + "\n")
-        print(f"Wrote {len(records)} session records to {out_path}")
+    if not args.summary_only:
+        if args.output:
+            out_path = Path(args.output)
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(out_path, "w") as f:
+                for rec in records:
+                    f.write(json.dumps(rec) + "\n")
+            print(f"JSONL:    {out_path}")
+        if args.html:
+            write_html(records, Path(args.html), args.since)
+        if args.markdown:
+            write_markdown(records, Path(args.markdown), args.since)
 
     summarise(records)
 

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -75,8 +75,6 @@ def bash_label(command: str, subcommands: bool = False) -> str:
         if word.startswith("#"):
             return "_shell"
         effective.append(Path(word).name if not effective else word)
-        if not effective:
-            continue
         break
     if not effective:
         return "_shell"

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -34,7 +34,7 @@ _BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
 _SUBCOMMAND_DEPTH: dict[str, int] = {
     "gh": 3,
     "git": 2,
-    "uv": 2,
+    "uv": 2,       # uv sync, uv add, uv lock — uv run handled by _TRANSPARENT_RUNNERS
     "docker": 2,
     "just": 2,
     "chezmoi": 2,
@@ -42,6 +42,21 @@ _SUBCOMMAND_DEPTH: dict[str, int] = {
     "kubectl": 2,
     "cargo": 2,
     "npm": 2,
+}
+
+# CLIs that act as transparent runners: `uv run python` → label is `python`.
+# The word after the subcommand becomes the effective label.
+_TRANSPARENT_RUNNERS: dict[str, str] = {
+    "uv": "run",    # uv run <cmd> → <cmd>
+}
+
+# Normalise variant spellings to a canonical label.
+_LABEL_ALIASES: dict[str, str] = {
+    "python3": "python",
+    "python3.10": "python",
+    "python3.11": "python",
+    "python3.12": "python",
+    "python3.13": "python",
 }
 
 
@@ -67,30 +82,39 @@ def bash_label(command: str, subcommands: bool = False) -> str:
         return "_shell"
 
     cli = effective[0]
-    if not subcommands or cli not in _SUBCOMMAND_DEPTH:
-        return cli
+
+    if not subcommands:
+        return _LABEL_ALIASES.get(cli, cli)
+
+    # Transparent runners: `uv run python` → `python`
+    if cli in _TRANSPARENT_RUNNERS:
+        trigger = _TRANSPARENT_RUNNERS[cli]
+        raw_words = command.split()
+        idx = next(
+            (i for i, w in enumerate(raw_words) if w not in _BASH_WRAPPERS and "=" not in w),
+            0,
+        )
+        tail = [w for w in raw_words[idx + 1:] if not w.startswith("-") and "=" not in w]
+        if tail and tail[0] == trigger and len(tail) > 1:
+            inner = Path(tail[1]).name
+            return _LABEL_ALIASES.get(inner, inner)
+        # Fall through to depth-based logic (uv sync, uv add, etc.)
+
+    if cli not in _SUBCOMMAND_DEPTH:
+        return _LABEL_ALIASES.get(cli, cli)
 
     # Collect up to depth words, stopping at flags
     depth = _SUBCOMMAND_DEPTH[cli]
     parts = [cli]
-    remaining = [w for w in words[words.index(command.split()[0]) + 1:] if w]
-    # Re-derive from original words after wrappers
     raw_words = command.split()
-    idx = 0
-    # Skip wrappers/env-vars to find CLI position
-    for i, w in enumerate(raw_words):
-        if w in _BASH_WRAPPERS:
-            continue
-        if "=" in w and not w.startswith("-"):
-            continue
-        idx = i
-        break
+    idx = next(
+        (i for i, w in enumerate(raw_words) if w not in _BASH_WRAPPERS and "=" not in w),
+        0,
+    )
     for w in raw_words[idx + 1:]:
         if len(parts) >= depth:
             break
-        if w.startswith("-"):
-            break
-        if "=" in w and not w.startswith("-"):
+        if w.startswith("-") or ("=" in w and not w.startswith("-")):
             break
         parts.append(w)
 
@@ -184,7 +208,7 @@ def ngrams(stream: list[str], n: int) -> list[tuple[str, ...]]:
     return [tuple(stream[i : i + n]) for i in range(len(stream) - n + 1)]
 
 
-def compute_ngrams(records: list[dict], top_n: int = 20) -> list[tuple[tuple, int]]:
+def compute_ngrams(records: list[dict], top_n: int = 50) -> list[tuple[tuple, int]]:
     counts: Counter = Counter()
     for rec in records:
         flat = [t for turn in rec["sequence"] for t in turn["tools"]]
@@ -206,7 +230,7 @@ def project_stats(records: list[dict]) -> list[tuple[str, int, int]]:
     )
 
 
-def summarise(records: list[dict], top_n: int = 20) -> None:
+def summarise(records: list[dict], top_n: int = 50) -> None:
     top = compute_ngrams(records, top_n)
     print(f"\nTop {top_n} tool n-grams (size 2–4) across {len(records)} sessions:\n")
     print(f"  {'Count':>6}  Pattern")

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python3
+"""
+Extract tool-call sequences from Claude Code session JSONL files.
+
+Discovers ~/.claude/projects/**/*.jsonl, parses assistant turns, and emits
+per-session JSONL with ordered tool sequences. Prints a top-20 n-gram summary.
+
+Usage:
+    python3 scripts/claude-chains.py
+    python3 scripts/claude-chains.py --since 30
+    python3 scripts/claude-chains.py --project atomicguard --since 7
+    python3 scripts/claude-chains.py --output /tmp/chains-7d.jsonl
+    python3 scripts/claude-chains.py --summary-only
+"""
+
+import argparse
+import json
+import sys
+import time
+from collections import Counter
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+CLAUDE_DIR = Path.home() / ".claude" / "projects"
+OUTPUT_DIR = Path("output")
+
+_BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
+
+
+def bash_label(command: str) -> str:
+    """Return the effective command name from a Bash input.command string."""
+    if not command:
+        return "_shell"
+    words = command.split()
+    for word in words:
+        if word in _BASH_WRAPPERS:
+            continue
+        # Skip env VAR=value tokens
+        if "=" in word and not word.startswith("-"):
+            continue
+        if word.startswith("$") or word.startswith("{"):
+            return "_shell"
+        # Strip path prefix: /usr/bin/git -> git
+        return Path(word).name or "_shell"
+    return "_shell"
+
+
+def extract_tool_label(block: dict) -> str:
+    """Return a label for a tool_use block."""
+    name = block.get("name", "")
+    if name == "Bash":
+        cmd = block.get("input", {}).get("command", "")
+        return bash_label(cmd)
+    return name
+
+
+def parse_session(path: Path) -> dict | None:
+    """Parse a session JSONL file into a sequence record. Returns None on error."""
+    turns: list[dict] = []
+    session_id = path.stem  # filename without .jsonl
+
+    try:
+        with open(path) as f:
+            for raw in f:
+                raw = raw.strip()
+                if not raw:
+                    continue
+                try:
+                    obj = json.loads(raw)
+                except json.JSONDecodeError:
+                    continue
+
+                if obj.get("type") != "assistant":
+                    continue
+
+                # Timestamp is top-level on the record
+                ts = obj.get("timestamp", "")
+                uuid = obj.get("uuid", "")
+                content = obj.get("message", {}).get("content", [])
+
+                if not isinstance(content, list):
+                    continue
+
+                tool_labels = [
+                    extract_tool_label(b)
+                    for b in content
+                    if isinstance(b, dict) and b.get("type") == "tool_use"
+                ]
+
+                if not tool_labels:
+                    continue
+
+                turns.append({"ts": ts, "uuid": uuid[:8], "tools": tool_labels})
+
+    except OSError:
+        return None
+
+    if not turns:
+        return None
+
+    turns.sort(key=lambda t: t["ts"])
+    project_key = path.parent.name
+
+    return {
+        "session_id": session_id,
+        "project_key": project_key,
+        "first_ts": turns[0]["ts"],
+        "last_ts": turns[-1]["ts"],
+        "turns": len(turns),
+        "sequence": turns,
+    }
+
+
+def discover_sessions(since_days: int, project: str | None) -> list[Path]:
+    """Return .jsonl session files modified within since_days, optionally filtered by project."""
+    if not CLAUDE_DIR.exists():
+        return []
+
+    cutoff = time.time() - since_days * 86400
+    paths = []
+
+    for project_dir in CLAUDE_DIR.iterdir():
+        if not project_dir.is_dir():
+            continue
+        if project and project not in project_dir.name:
+            continue
+        for f in project_dir.glob("*.jsonl"):
+            if f.stat().st_mtime >= cutoff:
+                paths.append(f)
+
+    return sorted(paths)
+
+
+def ngrams(stream: list[str], n: int) -> list[tuple[str, ...]]:
+    return [tuple(stream[i : i + n]) for i in range(len(stream) - n + 1)]
+
+
+def summarise(records: list[dict], top_n: int = 20) -> None:
+    counts: Counter = Counter()
+    for rec in records:
+        flat = [t for turn in rec["sequence"] for t in turn["tools"]]
+        for n in (2, 3, 4):
+            counts.update(ngrams(flat, n))
+
+    print(f"\nTop {top_n} tool n-grams (size 2–4) across {len(records)} sessions:\n")
+    print(f"  {'Count':>6}  Pattern")
+    print(f"  {'------':>6}  -------")
+    for pattern, count in counts.most_common(top_n):
+        print(f"  {count:>6}  {' → '.join(pattern)}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Extract Claude Code tool-call sequences")
+    parser.add_argument("--since", type=int, default=7, metavar="DAYS",
+                        help="Include sessions modified within N days (default: 7)")
+    parser.add_argument("--project", metavar="SUBSTR",
+                        help="Filter by substring of encoded project dir name")
+    parser.add_argument("--output", metavar="FILE",
+                        help="Write per-session JSONL to this path")
+    parser.add_argument("--summary-only", action="store_true",
+                        help="Print n-gram summary only (ignores --output)")
+    args = parser.parse_args()
+
+    paths = discover_sessions(args.since, args.project)
+    if not paths:
+        print("No session files found.", file=sys.stderr)
+        sys.exit(1)
+
+    records = []
+    for p in paths:
+        rec = parse_session(p)
+        if rec:
+            records.append(rec)
+
+    if not records:
+        print("No tool-call sequences found in selected sessions.", file=sys.stderr)
+        sys.exit(1)
+
+    if not args.summary_only and args.output:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(out_path, "w") as f:
+            for rec in records:
+                f.write(json.dumps(rec) + "\n")
+        print(f"Wrote {len(records)} session records to {out_path}")
+
+    summarise(records)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/claude-chains.py
+++ b/scripts/claude-chains.py
@@ -13,6 +13,7 @@ Usage:
     python3 scripts/claude-chains.py --html /tmp/chains.html
     python3 scripts/claude-chains.py --markdown /tmp/chains.md
     python3 scripts/claude-chains.py --summary-only
+    python3 scripts/claude-chains.py --subcommands --summary-only
 """
 
 import argparse
@@ -27,11 +28,28 @@ CLAUDE_DIR = Path.home() / ".claude" / "projects"
 
 _BASH_WRAPPERS = {"sudo", "env", "time", "nice", "nohup", "watch"}
 
+# CLIs where subcommands carry workflow signal.
+# Value = number of words to keep (including the CLI name itself).
+# gh needs 3: `gh run watch`, `gh pr create`, `gh issue list`
+_SUBCOMMAND_DEPTH: dict[str, int] = {
+    "gh": 3,
+    "git": 2,
+    "uv": 2,
+    "docker": 2,
+    "just": 2,
+    "chezmoi": 2,
+    "systemctl": 2,
+    "kubectl": 2,
+    "cargo": 2,
+    "npm": 2,
+}
 
-def bash_label(command: str) -> str:
+
+def bash_label(command: str, subcommands: bool = False) -> str:
     if not command:
         return "_shell"
     words = command.split()
+    effective: list[str] = []
     for word in words:
         if word in _BASH_WRAPPERS:
             continue
@@ -39,19 +57,55 @@ def bash_label(command: str) -> str:
             continue
         if word.startswith("$") or word.startswith("{"):
             return "_shell"
-        return Path(word).name or "_shell"
-    return "_shell"
+        if word.startswith("#"):
+            return "_shell"
+        effective.append(Path(word).name if not effective else word)
+        if not effective:
+            continue
+        break
+    if not effective:
+        return "_shell"
+
+    cli = effective[0]
+    if not subcommands or cli not in _SUBCOMMAND_DEPTH:
+        return cli
+
+    # Collect up to depth words, stopping at flags
+    depth = _SUBCOMMAND_DEPTH[cli]
+    parts = [cli]
+    remaining = [w for w in words[words.index(command.split()[0]) + 1:] if w]
+    # Re-derive from original words after wrappers
+    raw_words = command.split()
+    idx = 0
+    # Skip wrappers/env-vars to find CLI position
+    for i, w in enumerate(raw_words):
+        if w in _BASH_WRAPPERS:
+            continue
+        if "=" in w and not w.startswith("-"):
+            continue
+        idx = i
+        break
+    for w in raw_words[idx + 1:]:
+        if len(parts) >= depth:
+            break
+        if w.startswith("-"):
+            break
+        if "=" in w and not w.startswith("-"):
+            break
+        parts.append(w)
+
+    return " ".join(parts)
 
 
-def extract_tool_label(block: dict) -> str:
+def extract_tool_label(block: dict, subcommands: bool = False) -> str:
     name = block.get("name", "")
     if name == "Bash":
         cmd = block.get("input", {}).get("command", "")
-        return bash_label(cmd)
+        return bash_label(cmd, subcommands)
     return name
 
 
-def parse_session(path: Path) -> dict | None:
+def parse_session(path: Path, subcommands: bool = False) -> dict | None:
     turns: list[dict] = []
     session_id = path.stem
 
@@ -77,9 +131,10 @@ def parse_session(path: Path) -> dict | None:
                     continue
 
                 tool_labels = [
-                    extract_tool_label(b)
+                    label
                     for b in content
                     if isinstance(b, dict) and b.get("type") == "tool_use"
+                    and (label := extract_tool_label(b, subcommands)) != "_shell"
                 ]
 
                 if not tool_labels:
@@ -322,6 +377,8 @@ def main() -> None:
                         help="Write GitHub-renderable Mermaid markdown to this path")
     parser.add_argument("--summary-only", action="store_true",
                         help="Print n-gram summary only (ignores --output/--html/--markdown)")
+    parser.add_argument("--subcommands", action="store_true",
+                        help="Expand Bash labels to include subcommands (e.g. 'git commit', 'gh run watch')")
     args = parser.parse_args()
 
     paths = discover_sessions(args.since, args.project)
@@ -331,7 +388,7 @@ def main() -> None:
 
     records = []
     for p in paths:
-        rec = parse_session(p)
+        rec = parse_session(p, subcommands=args.subcommands)
         if rec:
             records.append(rec)
 


### PR DESCRIPTION
## Summary

Adds a lightweight local telemetry pipeline that captures Claude Code tool usage into a SQLite store for retrospective analysis. Feeds two goals: personal dev analytics (hours/project/tool) and empirical pattern input for `workflow-service` intent registry.

See [`docs/claude-telemetry-strategy.md`](docs/claude-telemetry-strategy.md) for the full rationale.

## Components

| File | Purpose |
|---|---|
| `run_once_after_install-otel-collector.sh.tmpl` | Pop-mini-gated install; pulls image, runs backfill, enables timer |
| `dot_local/share/otel/compose.yml` | Single otelcol-contrib container (`network_mode: host`) |
| `dot_local/share/otel/config.yaml` | OTLP HTTP (4318) + gRPC (4317) receivers, rotating file exporters |
| `dot_local/share/otel/schema.sql` | SQLite schema: `events` (live), `legacy_events` (backfill), `ingest_state` |
| `dot_local/share/otel/ingest.py` | OTel JSONL → `events`; idempotent via inode+offset tracking |
| `dot_local/share/otel/backfill.py` | `~/.claude/projects/**/*.jsonl` → `legacy_events`; covers subagent traces |
| `dot_local/bin/executable_otel-stats` | bash/sqlite3 CLI: hours-per-week, by-project, by-tool, tokens, etc. |
| `dot_config/systemd/user/otel-ingest.{service,timer}` | User-level timer, runs ingest.py every 5 min |
| `dot_zshrc` | OTel env vars; pop-mini always-on, other machines opt-in |
| `docs/claude-telemetry.md` | Ops reference (rewritten from planning doc) |

## Fixes applied (from code review)

- `PROJECT_PREFIX` now derived from `Path.home()` — portable across machines/usernames
- `is_relative_to` (Python 3.9+) replaced with `str.startswith` — safe on 3.8
- `$(hostname)` replaced with `$HOST` zsh builtin — no subshell on every shell start
- SQL injection in `otel-stats --project` filter sanitised
- Missing trailing newline in `dot_zshrc` added

## Test plan

- [ ] `chezmoi apply --dry-run` on pop-mini — deploys cleanly
- [ ] `docker compose -f ~/.local/share/otel/compose.yml up -d` — collector healthy
- [ ] `python3 ~/.local/share/otel/backfill.py --verbose` — ingests historical sessions
- [ ] `otel-stats hours-per-week --since=2026-01-01` — returns data
- [ ] `otel-stats by-project` — shows Manta + AtomicGuard split
- [ ] `systemctl --user status otel-ingest.timer` — active and running
- [ ] New shell on pop-mini: `echo $CLAUDE_CODE_ENABLE_TELEMETRY` → `1`
- [ ] New shell on non-pop-mini without opt-in file: var unset