### PR TITLE
feat: add opencode AI coding assistant

### DIFF
--- a/dot_config/opencode/opencode.jsonc.tmpl
+++ b/dot_config/opencode/opencode.jsonc.tmpl
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "instructions": [
+    "{{ .chezmoi.homeDir }}/.context/feedback_communication_style.md",
+    "{{ .chezmoi.homeDir }}/.context/feedback_professional_bar_on_solutions.md"
+  ]
+}

--- a/dot_config/opencode/opencode.jsonc.tmpl
+++ b/dot_config/opencode/opencode.jsonc.tmpl
@@ -3,5 +3,8 @@
   "instructions": [
     "{{ .chezmoi.homeDir }}/.context/feedback_communication_style.md",
     "{{ .chezmoi.homeDir }}/.context/feedback_professional_bar_on_solutions.md"
-  ]
+  ],
+  "experimental": {
+    "openTelemetry": true
+  }
 }

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -573,7 +573,7 @@ cmd_doctor() {
   done
 
   header "Development Tools"
-  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot kubectl cmake git-lfs devenv direnv)
+  local tools_dev=(git zsh tmux fzf docker python3 poetry just gh curl sysbak rsnapshot kubectl cmake git-lfs devenv direnv opencode)
   for tool in "${tools_dev[@]}"; do
     check_tool "$tool"
   done

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -261,7 +261,8 @@ _sysbak_completion() {
 }
 compdef _sysbak_completion sysbak 2>/dev/null
 
-# Claude Code OpenTelemetry export → pop-mini central collector.
+# OpenTelemetry export → pop-mini central collector.
+# Used by Claude Code and opencode (both read standard OTEL_* env vars).
 # pop-mini: always-on (it hosts the collector, see ~/.local/share/otel/).
 # Other machines: opt-in via `touch ~/.config/claude-telemetry/enabled`.
 if [[ "$HOST" == "pop-mini" ]]; then

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -23,7 +23,8 @@
      "just"
      "shellcheck"
      "kubectl"
-     "cmake" -}}
+     "cmake"
+     "anomalyco/tap/opencode" -}}
 
 {{ $modernCli := list
      "bat"


### PR DESCRIPTION
## Summary

- Install via `brew install anomalyco/tap/opencode` (cross-platform via Homebrew tap)
- Add `opencode` to `sysup doctor` dev tools check
- Track `~/.config/opencode/opencode.jsonc` via chezmoi as a template (fixes hardcoded `/home/mt` paths — uses `{{ .chezmoi.homeDir }}` instead)

## Checklist

- [x] Template renders correctly (`chezmoi execute-template`)
- [x] Added to install script `$brewPackages`
- [x] Added to `sysup doctor` `tools_dev`