### PR TITLE
Add Termux (Android) support across dotfiles

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -1,9 +1,18 @@
+{{- /* Termux reports os "linux" with no /etc/os-release. Detect it via the
+       TERMUX_VERSION env var or the Termux prefix directory. */ -}}
+{{- $isTermux := false -}}
+{{- if env "TERMUX_VERSION" -}}{{- $isTermux = true -}}{{- end -}}
+{{- if stat "/data/data/com.termux/files/usr" -}}{{- $isTermux = true -}}{{- end -}}
+
 {{- $osID := .chezmoi.os -}}
-{{- if (and (eq .chezmoi.os "linux") (hasKey .chezmoi.osRelease "id")) -}}
+{{- if $isTermux -}}
+{{-   $osID = "linux-termux" -}}
+{{- else if (and (eq .chezmoi.os "linux") (hasKey .chezmoi.osRelease "id")) -}}
 {{-   $osID = printf "%s-%s" .chezmoi.os .chezmoi.osRelease.id -}}
 {{- end -}}
 
 
 [data]
     osid = {{ $osID | quote }}
-    install_nix = {{ if eq .chezmoi.os "linux" }}true{{ else }}false{{ end }}
+    is_termux = {{ $isTermux }}
+    install_nix = {{ if and (eq .chezmoi.os "linux") (not $isTermux) }}true{{ else }}false{{ end }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@ This file contains specific instructions for Claude Code when working with this 
 ## Repository Context
 
 This is a chezmoi-managed dotfiles repository that supports:
-- **Platforms**: macOS, Linux, and WSL
+- **Platforms**: macOS, Linux, WSL, and Termux (Android)
 - **Shell**: Zsh with oh-my-zsh, antigen, and powerlevel10k
 - **Package Management**: Homebrew (cross-platform)
 - **Node.js**: fnm for version management
@@ -64,6 +64,13 @@ The zsh configuration uses these variables:
 - `IS_WSL`: Windows Subsystem for Linux
 - `IS_MACOS`: macOS
 - `IS_LINUX`: Regular Linux
+- `IS_TERMUX`: Termux on Android (detected via `$TERMUX_VERSION` or the Termux prefix dir)
+
+Termux notes: no root/`sudo`, no systemd, no Homebrew/Docker/Nix. Packages are
+installed via `pkg` (an apt wrapper) instead of `apt-get`/`brew`. chezmoi reports
+the OS as `linux`; the install scripts detect Termux separately and set
+`osid = "linux-termux"` plus the `is_termux` template data flag. The terminal
+font is a single `~/.termux/font.ttf` (no fontconfig/`fc-cache`).
 
 ## Key Files
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Dotfiles
 
-Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/) for macOS, Linux, and WSL.
+Cross-platform dotfiles managed with [chezmoi](https://www.chezmoi.io/) for macOS, Linux, WSL, and Termux (Android).
 
 ## Features
 
-- **Cross-platform support**: Works on macOS, Linux, and WSL
+- **Cross-platform support**: Works on macOS, Linux, WSL, and Termux (Android)
 - **Modern CLI tools**: bat, eza, fd, delta, ncdu, httpie, tmux, and more
 - **Shell configuration**: Zsh with oh-my-zsh, antigen, and powerlevel10k
 - **Remote development**: Tmux configuration with session management helpers
@@ -31,6 +31,9 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
    
    # Linux/WSL
    curl -sfL https://git.io/chezmoi | sh
+
+   # Termux (Android)
+   pkg install chezmoi
    ```
 
 2. Initialize with this repository:
@@ -98,6 +101,14 @@ sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply $GITHUB_USERNAME
 - Windows Subsystem for Linux support
 - WSL-specific aliases and configurations
 - Docker integration handling
+
+### Termux (Android)
+- Detected via `$TERMUX_VERSION` / the Termux prefix directory
+- Packages installed with `pkg` (no root/`sudo`, no Homebrew/apt)
+- Full zsh + oh-my-zsh + antigen + powerlevel10k setup
+- Skips Android-incompatible steps: Docker, systemd, Nix, fontconfig
+- Terminal font installed to `~/.termux/font.ttf`
+- Backups (`sysbak`) are unsupported — use git to back up dotfiles
 
 ## Customization
 

--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -63,6 +63,8 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
 elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
   # shellcheck disable=SC2034
   IS_TERMUX=true
+  # shellcheck disable=SC2034
+  IS_LINUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   # shellcheck disable=SC2034
   IS_WSL=true

--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -56,15 +56,28 @@ IS_WSL=false
 IS_MACOS=false
 # shellcheck disable=SC2034
 IS_LINUX=false
+IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
+elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+  # shellcheck disable=SC2034
+  IS_TERMUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   # shellcheck disable=SC2034
   IS_WSL=true
 else
   # shellcheck disable=SC2034
   IS_LINUX=true
+fi
+
+# rsnapshot/USB/cron backups need root + a mounted block device — neither
+# exists on unrooted Android. Bail early with a clear message instead of
+# failing partway through a sudo prompt that can never succeed.
+if [ "$IS_TERMUX" = true ]; then
+  echo "sysbak is not supported on Termux (no root, no rsnapshot, no USB mounts)." >&2
+  echo "Back up your dotfiles with git (push to your remote) instead." >&2
+  exit 0
 fi
 
 # --- Configuration ------------------------------------------------------------

--- a/dot_local/bin/executable_sysbak
+++ b/dot_local/bin/executable_sysbak
@@ -60,7 +60,7 @@ IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
-elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+elif [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
   # shellcheck disable=SC2034
   IS_TERMUX=true
   # shellcheck disable=SC2034

--- a/dot_local/bin/executable_sysmon
+++ b/dot_local/bin/executable_sysmon
@@ -45,9 +45,15 @@ has() { command -v "$1" &>/dev/null; }
 IS_WSL=false
 IS_MACOS=false
 IS_LINUX=false
+IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
+elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+  # Termux: a userspace Linux on Android. Treat as Linux for /proc-based
+  # readouts but keep the flag so root/systemd paths can opt out.
+  IS_LINUX=true
+  IS_TERMUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   IS_WSL=true
 else
@@ -147,6 +153,8 @@ get_os_info() {
     local distro
     distro=$(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo "Linux")
     echo "WSL - $distro ($(uname -m))"
+  elif [ "$IS_TERMUX" = true ]; then
+    echo "Termux on Android (${TERMUX_VERSION:-unknown}) ($(uname -m))"
   else
     local distro
     distro=$(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo "Linux")

--- a/dot_local/bin/executable_sysmon
+++ b/dot_local/bin/executable_sysmon
@@ -49,7 +49,7 @@ IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
-elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+elif [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
   # Termux: a userspace Linux on Android. Treat as Linux for /proc-based
   # readouts but keep the flag so root/systemd paths can opt out.
   IS_LINUX=true

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -626,7 +626,8 @@ cmd_doctor() {
   echo "  User:     $(whoami)"
 
   header "Package Managers"
-  local tools_pm=(brew apt-get pkg chezmoi fnm node npm uv pipx nix)
+  local tools_pm=(brew apt-get chezmoi fnm node npm uv pipx nix)
+  [ "$IS_TERMUX" = true ] && tools_pm+=(pkg)
   for tool in "${tools_pm[@]}"; do
     check_tool "$tool"
   done

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -50,7 +50,7 @@ IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
-elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+elif [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
   IS_TERMUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   IS_WSL=true

--- a/dot_local/bin/executable_sysup
+++ b/dot_local/bin/executable_sysup
@@ -46,9 +46,12 @@ has() { command -v "$1" &>/dev/null; }
 IS_WSL=false
 IS_MACOS=false
 IS_LINUX=false
+IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
+elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+  IS_TERMUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   IS_WSL=true
 else
@@ -134,6 +137,8 @@ brew_repair() {
 
 apt_status() {
   header "APT"
+  # Termux ships apt but has no sudo/root — the pkg module handles it instead.
+  if [ "$IS_TERMUX" = true ]; then summary_skip "apt"; return; fi
   if ! has apt-get; then summary_skip "apt"; return; fi
   info "Updating package index..."
   if sudo apt-get update -qq 2>/dev/null; then
@@ -153,6 +158,7 @@ apt_status() {
 
 apt_upgrade() {
   header "APT"
+  if [ "$IS_TERMUX" = true ]; then summary_skip "apt"; return; fi
   if ! has apt-get; then summary_skip "apt"; return; fi
   # Use dist-upgrade (full-upgrade) to handle dependency changes,
   # new packages, and removals — required for kernels, drivers, and
@@ -166,6 +172,7 @@ apt_upgrade() {
 
 apt_repair() {
   header "APT"
+  if [ "$IS_TERMUX" = true ]; then summary_skip "apt"; return; fi
   if ! has apt-get; then summary_skip "apt"; return; fi
   info "Completing interrupted installs..."
   sudo dpkg --configure -a
@@ -176,6 +183,53 @@ apt_repair() {
   info "Removing orphaned packages..."
   sudo apt-get autoremove -y
   summary_ok "apt"
+}
+
+# --- 2b. pkg (Termux) ---------------------------------------------------------
+# Termux's package manager. No sudo; `pkg` wraps apt for the single user.
+
+pkg_status() {
+  [ "$IS_TERMUX" = true ] || return 0
+  header "pkg (Termux)"
+  if ! has pkg; then summary_skip "pkg"; return; fi
+  info "Updating package index..."
+  if pkg update -y 2>/dev/null; then
+    local upgradable
+    upgradable=$(apt list --upgradable 2>/dev/null | grep -v "^Listing")
+    if [ -n "$upgradable" ]; then
+      echo "$upgradable"
+    else
+      success "All packages up to date"
+    fi
+    summary_ok "pkg"
+  else
+    warn "pkg update failed"
+    summary_fail "pkg"
+  fi
+}
+
+pkg_upgrade() {
+  [ "$IS_TERMUX" = true ] || return 0
+  header "pkg (Termux)"
+  if ! has pkg; then summary_skip "pkg"; return; fi
+  if pkg upgrade -y && apt autoremove -y 2>/dev/null; then
+    summary_ok "pkg"
+  else
+    summary_fail "pkg"
+  fi
+}
+
+pkg_repair() {
+  [ "$IS_TERMUX" = true ] || return 0
+  header "pkg (Termux)"
+  if ! has pkg; then summary_skip "pkg"; return; fi
+  info "Completing interrupted installs..."
+  dpkg --configure -a 2>/dev/null || true
+  info "Resolving broken dependencies..."
+  apt --fix-broken install -y 2>/dev/null || true
+  info "Cleaning package cache..."
+  apt clean 2>/dev/null || true
+  summary_ok "pkg"
 }
 
 # --- 3. fnm (Node.js) --------------------------------------------------------
@@ -465,6 +519,7 @@ cmd_status() {
   info "Checking system status..."
   brew_status
   apt_status
+  pkg_status
   fnm_status
   uv_status
   pipx_status
@@ -480,6 +535,7 @@ cmd_upgrade() {
   info "Upgrading system packages..."
   brew_upgrade
   apt_upgrade
+  pkg_upgrade
   fnm_upgrade
   uv_upgrade
   pipx_upgrade
@@ -509,6 +565,7 @@ cmd_repair() {
   info "Repairing system packages..."
   brew_repair
   apt_repair
+  pkg_repair
   print_summary
 }
 
@@ -560,6 +617,8 @@ cmd_doctor() {
     echo "  OS:       macOS $(sw_vers -productVersion 2>/dev/null || echo 'unknown')"
   elif [ "$IS_WSL" = true ]; then
     echo "  OS:       WSL ($(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo 'unknown'))"
+  elif [ "$IS_TERMUX" = true ]; then
+    echo "  OS:       Termux (Android, ${TERMUX_VERSION:-unknown})"
   elif [ "$IS_LINUX" = true ]; then
     echo "  OS:       $(grep PRETTY_NAME /etc/os-release 2>/dev/null | cut -d'"' -f2 || echo 'Linux')"
   fi
@@ -567,7 +626,7 @@ cmd_doctor() {
   echo "  User:     $(whoami)"
 
   header "Package Managers"
-  local tools_pm=(brew apt-get chezmoi fnm node npm uv pipx nix)
+  local tools_pm=(brew apt-get pkg chezmoi fnm node npm uv pipx nix)
   for tool in "${tools_pm[@]}"; do
     check_tool "$tool"
   done

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -20,9 +20,12 @@ setopt HIST_REDUCE_BLANKS        # Remove superfluous blanks before recording en
 IS_WSL=false
 IS_MACOS=false
 IS_LINUX=false
+IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
+elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+  IS_TERMUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   IS_WSL=true
 else
@@ -162,6 +165,7 @@ if [ -z "$TMUX" ] && [ -z "$VSCODE_INJECTION" ] && [ -t 1 ]; then
   _platform="Linux"
   [ "$IS_MACOS" = true ] && _platform="macOS"
   [ "$IS_WSL" = true ] && _platform="WSL"
+  [ "$IS_TERMUX" = true ] && _platform="Termux"
 
   echo ""
   echo "  \033[1m${_hostname}\033[0m  \033[2m${_platform}\033[0m"
@@ -213,7 +217,9 @@ _dev_completion() {
   local -a subcmds sessions projects
   subcmds=(claude layout detach kill kill-all help)
   sessions=(${(f)"$(tmux list-sessions -F '#S' 2>/dev/null)"})
-  projects=(${(f)"$(/usr/bin/find ~/Projects -maxdepth 3 -name .git -type d 2>/dev/null | sed 's|.*/Projects/||;s|/\.git$||' | sort)"})
+  # `command find` bypasses the fd alias without hardcoding /usr/bin/find,
+  # which doesn't exist on Termux (find lives in $PREFIX/bin).
+  projects=(${(f)"$(command find ~/Projects -maxdepth 3 -name .git -type d 2>/dev/null | sed 's|.*/Projects/||;s|/\.git$||' | sort)"})
   # Add custom-path projects from config
   if [ -f ~/.config/dev/config ]; then
     local -a config_projects

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -24,7 +24,7 @@ IS_TERMUX=false
 
 if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
-elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
+elif [ -n "${TERMUX_VERSION:-}" ] || [ -d /data/data/com.termux/files/usr ]; then
   IS_TERMUX=true
   IS_LINUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then

--- a/dot_zshrc
+++ b/dot_zshrc
@@ -26,6 +26,7 @@ if [[ "$OSTYPE" == "darwin"* ]]; then
   IS_MACOS=true
 elif [ -n "$TERMUX_VERSION" ] || [ -d /data/data/com.termux/files/usr ]; then
   IS_TERMUX=true
+  IS_LINUX=true
 elif [ -f /proc/version ] && grep -qi "microsoft\|wsl" /proc/version; then
   IS_WSL=true
 else

--- a/run_once_after_chsh.sh.tmpl
+++ b/run_once_after_chsh.sh.tmpl
@@ -3,4 +3,8 @@
 set -eufo pipefail
 
 echo 'To change your default shell to zsh, run:'
+{{ if .is_termux -}}
+echo '  chsh -s zsh'
+{{ else -}}
 echo "  chsh -s $(which zsh)"
+{{ end -}}

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -73,7 +73,71 @@ is_wsl() {
   fi
 }
 
-{{ if eq .osid "linux-debian" "linux-raspbian" "linux-pop" "linux-ubuntu" -}}
+{{ if .is_termux -}}
+echo '🤖 Installing Termux (Android) packages'
+
+# Termux has no sudo/root and installs via `pkg` (an apt wrapper). Package
+# names differ from Debian, and Debian-only packages (docker, lm-sensors,
+# mosquitto, fontconfig, …) have no Termux equivalent and are omitted.
+pkg update -y || true
+
+install_pkg_packages() {
+  local packages=("$@")
+  local failed_packages=()
+  local current=0 total=${#packages[@]}
+  echo "Installing $total Termux packages..."
+  for package in "${packages[@]}"; do
+    current=$((current + 1))
+    if pkg install -y "$package" 2>&1; then
+      echo "  [$current/$total] $package ✓"
+    else
+      echo "  [$current/$total] $package FAILED"
+      failed_packages+=("$package")
+    fi
+  done
+  if [ ${#failed_packages[@]} -gt 0 ]; then
+    echo "Failed: ${failed_packages[*]}"
+    echo "Retry: pkg install ${failed_packages[*]}"
+  fi
+}
+
+# Core tools, modern CLI replacements, and dev utilities available in Termux.
+# Failures are reported but never abort the run (some packages vary by repo).
+install_pkg_packages \
+  curl git direnv jq make rsync tree ripgrep fzf grep findutils coreutils \
+  zsh bash nano openssh gnupg python nodejs fnm \
+  btop tldr uv sqlite gh just shellcheck cmake \
+  bat eza fd git-delta ncdu tmux zoxide duf hyperfine procs git-lfs \
+  pandoc ffmpeg yt-dlp p7zip yq
+
+# Node via Termux's fnm (Homebrew is unavailable on Android). Falls back to the
+# nodejs package installed above if fnm isn't present.
+if command -v fnm >/dev/null 2>&1; then
+  echo 'Setting up fnm and installing Node.js LTS'
+  eval "$(fnm env --shell bash)"
+  fnm install --lts && fnm use lts-latest && fnm default lts-latest
+  echo "Node.js version: $(node --version 2>/dev/null || echo 'n/a')"
+elif command -v node >/dev/null 2>&1; then
+  echo "Using Termux nodejs package: $(node --version)"
+fi
+
+# Terminal font: Termux uses a single ~/.termux/font.ttf (no fontconfig/fc-cache).
+echo 'Installing MesloLGS NF as the Termux terminal font'
+mkdir -p "$HOME/.termux"
+if [ ! -f "$HOME/.termux/font.ttf" ]; then
+  if curl -fLo "$HOME/.termux/font.ttf" \
+       "https://github.com/romkatv/powerlevel10k-media/raw/master/MesloLGS%20NF%20Regular.ttf"; then
+    command -v termux-reload-settings >/dev/null 2>&1 && termux-reload-settings
+    echo 'Font installed — restart Termux if the prompt glyphs look wrong.'
+  else
+    echo 'Failed to download MesloLGS NF font.'
+  fi
+fi
+
+echo 'ℹ️  Termux: Docker/systemd/Nix/Homebrew are unavailable on Android and are skipped.'
+echo '   oh-my-zsh, antigen, and powerlevel10k are installed by the common section below.'
+
+{{ else if eq .osid "linux-debian" "linux-raspbian" "linux-pop" "linux-ubuntu" -}}
 echo '🐧 Installing Linux packages'
 
 {{ $linuxSpecific := list "python3" "python3-pip" "fontconfig" "openssh-client" "gpg" "lm-sensors" "sysstat" "mosquitto" "mosquitto-clients" "libasound2-dev" -}}

--- a/run_once_install-packages.sh.tmpl
+++ b/run_once_install-packages.sh.tmpl
@@ -105,13 +105,12 @@ install_pkg_packages() {
 # Failures are reported but never abort the run (some packages vary by repo).
 install_pkg_packages \
   curl git direnv jq make rsync tree ripgrep fzf grep findutils coreutils \
-  zsh bash nano openssh gnupg python nodejs fnm \
+  zsh bash nano openssh gnupg python fnm \
   btop tldr uv sqlite gh just shellcheck cmake \
   bat eza fd git-delta ncdu tmux zoxide duf hyperfine procs git-lfs \
   pandoc ffmpeg yt-dlp p7zip yq
 
-# Node via Termux's fnm (Homebrew is unavailable on Android). Falls back to the
-# nodejs package installed above if fnm isn't present.
+# Node via fnm (Homebrew is unavailable on Android).
 if command -v fnm >/dev/null 2>&1; then
   echo 'Setting up fnm and installing Node.js LTS'
   eval "$(fnm env --shell bash)"


### PR DESCRIPTION
chezmoi runs on Termux but the dotfiles assumed apt/sudo/Homebrew and
silently did almost nothing there. This adds first-class Termux support:

- .chezmoi.toml.tmpl: detect Termux (TERMUX_VERSION / prefix dir), set
  osid=linux-termux, expose is_termux data flag, disable Nix install
- run_once_install-packages.sh.tmpl: pkg-based install branch (no sudo),
  Termux package names, fnm/node, ~/.termux/font.ttf; skips
  Docker/systemd/Nix/Homebrew/fontconfig
- dot_zshrc: IS_TERMUX detection, Termux welcome label, replace hardcoded
  /usr/bin/find with 'command find' (Termux has no /usr/bin/find)
- sysup: pkg module (status/upgrade/repair, no sudo), apt steps step aside
  on Termux, doctor reports Termux + lists pkg
- sysmon: treat Termux as Linux for /proc reads, add OS label
- sysbak: bail early on Termux (no root/USB/rsnapshot)
- run_once_after_chsh: Termux-correct 'chsh -s zsh' hint
- docs: README + CLAUDE.md note Termux support

oh-my-zsh, antigen, and powerlevel10k install unchanged via the common
section. Verified: ./tests/test.sh quick passes, shellcheck clean.

https://claude.ai/code/session_01Grqp2H8rVQbFBnpMKPDcrr